### PR TITLE
chore: add GHCR build action

### DIFF
--- a/.github/workflows/build_and_release_image.yaml
+++ b/.github/workflows/build_and_release_image.yaml
@@ -1,0 +1,80 @@
+name: Release with goreleaser
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions: write-all # Necessary for the generate-build-provenance action with containers
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install cross-compilation tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+
+      - name: Set up latest stable Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Checkout out the repo
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: 1
+          fetch-depth: 1
+
+      # Set environment variables required by GoReleaser
+      - name: Set build environment variables
+        run: |
+          echo "GIT_STATE=$(if git diff-index --quiet HEAD --; then echo 'clean'; else echo 'dirty'; fi)" >> $GITHUB_ENV
+          echo "BUILD_HOST=$(hostname)" >> $GITHUB_ENV
+          echo "GO_VERSION=$(go version | awk '{print $3}')" >> $GITHUB_ENV
+          echo "BUILD_USER=$(whoami)" >> $GITHUB_ENV
+
+      - name: Docker Login
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release with goreleaser
+        uses: goreleaser/goreleaser-action@v6
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          version: '~> v2'
+          args: release --clean
+        id: goreleaser
+
+      - name: Process goreleaser output
+        id: process_goreleaser_output
+        run: |
+          echo "const fs = require('fs');" > process.js
+          echo 'const artifacts = ${{ steps.goreleaser.outputs.artifacts }}' >> process.js
+          echo "const firstNonNullDigest = artifacts.find(artifact => artifact.extra && artifact.extra.Digest != null)?.extra.Digest;" >> process.js
+          echo "console.log(firstNonNullDigest);" >> process.js
+          echo "fs.writeFileSync('digest.txt', firstNonNullDigest);" >> process.js
+          node process.js
+          echo "digest=$(cat digest.txt)" >> $GITHUB_OUTPUT
+
+      - name: Attest power-control binary amd64
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: dist/remote-console_linux_amd64_v3/remote-console
+      # TODO: ARM builds aren't viable yet
+      #- name: Attest power-control binary arm64
+      #  uses: actions/attest-build-provenance@v1
+      #  with:
+      #    subject-path: dist/pcs_linux_arm64_v8.0/power-control
+      - name: Generate build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-name: ghcr.io/openchami/remote-console
+          subject-digest: ${{ steps.process_goreleaser_output.outputs.digest }}
+          push-to-registry: true

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,134 @@
+version: 2.4
+
+project_name: remote-console
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod tidy
+
+builds:
+  - id: remote-console
+    main: ./cmd/remote-console
+    binary: remote-console
+    goos:
+      - linux
+    goarch:
+      - amd64
+      # TODO We want ARM builds, but need ARM base images and conman packages for this.
+      #- arm64
+    goamd64:
+      - v3
+    env:
+      - CGO_ENABLED=1
+      - >-
+        {{- if eq .Os "linux" }}
+          {{- if eq .Arch "arm64"}}CC=aarch64-linux-gnu-gcc{{- end }}
+        {{- end }}
+
+    ldflags:
+      - "-s -w -X main.GitCommit={{.Commit}} \
+         -X main.BuildTime={{.Timestamp}} \
+         -X main.Version={{.Version}} \
+         -X main.GitBranch={{.Branch}} \
+         -X main.GitTag={{.Tag}} \
+         -X main.GitState={{ .Env.GIT_STATE }} \
+         -X main.BuildHost={{ .Env.BUILD_HOST }} \
+         -X main.GoVersion={{ .Env.GO_VERSION }} \
+         -X main.BuildUser={{ .Env.BUILD_USER }} "
+
+dockers:
+  - image_templates:
+      - &amd64_linux_image ghcr.io/openchami/{{.ProjectName}}:{{ .Tag }}-amd64
+      - ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}-amd64
+      - ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}.{{ .Minor }}-amd64
+    use: buildx
+    build_flag_templates:
+      - "--pull"
+      - "--target=ubuntu-goreleaser"
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+    goarch: amd64
+    goamd64: v3
+    extra_files:
+      - LICENSE
+      - CHANGELOG.md
+      - README.md
+      - configs/
+      - scripts/
+
+  # TODO: more ARM config that isn't viable yet.
+  #- image_templates:
+  #    - &arm64v8_linux_image ghcr.io/openchami/{{.ProjectName}}:{{ .Tag }}-arm64
+  #    - ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}-arm64
+  #    - ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}.{{ .Minor }}-arm64
+  #  use: buildx
+  #  build_flag_templates:
+  #    - "--pull"
+  #    - "--platform=linux/arm64"
+  #    - "--label=org.opencontainers.image.created={{.Date}}"
+  #    - "--label=org.opencontainers.image.title={{.ProjectName}}"
+  #    - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  #    - "--label=org.opencontainers.image.version={{.Version}}"
+  #  goarch: arm64
+  #  extra_files:
+  #    - LICENSE
+  #    - CHANGELOG.md
+  #    - README.md
+  #    - configs/
+
+docker_manifests:
+  # TODO: ARM ARM ARM
+  - name_template: "ghcr.io/openchami/{{.ProjectName}}:latest"
+    image_templates:
+      - *amd64_linux_image
+      #- *arm64v8_linux_image
+
+  - name_template: "ghcr.io/openchami/{{.ProjectName}}:{{ .Tag }}"
+    image_templates:
+      - *amd64_linux_image
+      #- *arm64v8_linux_image
+
+  - name_template: "ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}"
+    image_templates:
+      - *amd64_linux_image
+      #- *arm64v8_linux_image
+
+  - name_template: "ghcr.io/openchami/{{.ProjectName}}:{{ .Major }}.{{ .Minor }}"
+    image_templates:
+      - *amd64_linux_image
+      #- *arm64v8_linux_image
+
+archives:
+  - formats: ["tar.gz"]
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    files:
+      - LICENSE
+      - CHANGELOG.md
+      - README.md
+
+checksum:
+  name_template: 'checksums.txt'
+snapshot:
+  version_template: "{{ incpatch .Version }}-next"
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+
+# The lines beneath this are called `modelines`. See `:help modeline`
+# Feel free to remove those if you don't want/use them.
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=cnqoj

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@
 # Dockerfile for the console-data service
 
 # Build will be where we build the go binary
-FROM docker.io/library/golang:1.24-alpine AS build
+FROM docker.io/library/golang:1.24-alpine AS build-alpine
 RUN set -eux \
     && apk add --upgrade --no-cache apk-tools \
     && apk update \
@@ -48,12 +48,31 @@ COPY go.sum $GOPATH/src/github.com/OpenCHAMI/remote-console/v2/go.sum
 
 RUN set -ex  && go build -C $GOPATH/src/github.com/OpenCHAMI/remote-console/v2/cmd/remote-console -v -tags musl -o /usr/local/bin/remote-console
 
-### Final Stage ###
+FROM docker.io/library/golang:1.24 AS build
+
+# Configure go env - installed as package but not quite configured
+ENV GOPATH=/usr/local/golib
+RUN export GOPATH=$GOPATH
+
+# set up go env
+RUN go env -w GO111MODULE=auto
+
+# Build the image
+COPY cmd $GOPATH/src/github.com/OpenCHAMI/remote-console/v2/cmd
+COPY configs configs
+COPY scripts scripts
+COPY internal $GOPATH/src/github.com/OpenCHAMI/remote-console/v2/internal
+COPY go.mod $GOPATH/src/github.com/OpenCHAMI/remote-console/v2/go.mod
+COPY go.sum $GOPATH/src/github.com/OpenCHAMI/remote-console/v2/go.sum
+
+RUN set -ex  && go build -C $GOPATH/src/github.com/OpenCHAMI/remote-console/v2/cmd/remote-console -v -o /usr/local/bin/remote-console
+
+### Alpine image ###
 # Start with a fresh image so build tools are not included
-FROM docker.io/alpine:3 AS base
+FROM docker.io/alpine:3 AS alpine
 
 # Copy in the needed files
-COPY --from=build /usr/local/bin/remote-console /app/
+COPY --from=build-alpine /usr/local/bin/remote-console /app/
 COPY scripts/conman.conf /app/conman_base.conf
 COPY scripts/conman.conf /etc/conman.conf
 COPY scripts/ssh-key-console /usr/bin
@@ -84,3 +103,71 @@ USER 65534:65534
 CMD [ "/app/remote-console" ]
 
 ENTRYPOINT [ "/sbin/tini", "--" ]
+
+### Alma UBI ###
+
+FROM almalinux/9-minimal:9.6 AS alma
+
+RUN microdnf -y install epel-release
+RUN microdnf -y install conman less vim openssh jq tar procps inotify-tools
+RUN microdnf -y clean all
+
+COPY --from=build /usr/local/bin/remote-console /app/
+COPY scripts/conman.conf /app/conman_base.conf
+COPY scripts/conman.conf /etc/conman.conf
+COPY scripts/ssh-key-console /usr/bin
+COPY scripts/ssh-pwd-console /usr/bin
+COPY configs /app/configs
+
+RUN chown -Rv 65534:65534 /app /etc/conman.conf
+USER 65534:65534
+
+RUN echo 'alias ll="ls -l"' > /app/bashrc
+RUN echo 'alias vi="vim"' >> /app/bashrc
+
+ENTRYPOINT ["/app/remote-console"]
+
+### Ubuntu
+
+FROM ubuntu:plucky AS ubuntu
+
+RUN apt -y update
+RUN apt -y install conman less vim ssh jq tar procps inotify-tools
+
+COPY --from=build /usr/local/bin/remote-console /app/
+COPY scripts/conman.conf /app/conman_base.conf
+COPY scripts/conman.conf /etc/conman.conf
+COPY scripts/ssh-key-console /usr/bin
+COPY scripts/ssh-pwd-console /usr/bin
+COPY configs /app/configs
+
+RUN chown -Rv 65534:65534 /app /etc/conman.conf
+USER 65534:65534
+
+RUN echo 'alias ll="ls -l"' > /app/bashrc
+RUN echo 'alias vi="vim"' >> /app/bashrc
+
+ENTRYPOINT ["/app/remote-console"]
+
+### Ubuntu, without build copy
+### Assume goreleaser has already compiled the binary and written it to ./remote-console
+
+FROM ubuntu:plucky AS ubuntu-goreleaser
+
+RUN apt -y update
+RUN apt -y install conman less vim ssh jq tar procps inotify-tools
+
+COPY remote-console /app/
+COPY scripts/conman.conf /app/conman_base.conf
+COPY scripts/conman.conf /etc/conman.conf
+COPY scripts/ssh-key-console /usr/bin
+COPY scripts/ssh-pwd-console /usr/bin
+COPY configs /app/configs
+
+RUN chown -Rv 65534:65534 /app /etc/conman.conf
+USER 65534:65534
+
+RUN echo 'alias ll="ls -l"' > /app/bashrc
+RUN echo 'alias vi="vim"' >> /app/bashrc
+
+ENTRYPOINT ["/app/remote-console"]


### PR DESCRIPTION
Add a goreleaser config and release on tag action adopted from power-control (https://github.com/OpenCHAMI/power-control/blob/v2.7.0/.goreleaser.yaml and https://github.com/OpenCHAMI/power-control/blob/v2.7.0/.github/workflows/build_and_release_image.yaml).

This won't run here until we merge and create a tag, so testing it has a chicken and egg problem. I've tested on a fork and gotten it to release (https://github.com/rainest/remote-console-tmp/actions/runs/16128895425 and https://github.com/rainest/remote-console-tmp/pkgs/container/remote-console) but may have missed something when diffing (the diff's not clean, as the fork needs additional changes to the repo URL and such).

Other OpenCHAMI projects release both AMD64 and ARM artifacts. remote-console's need for the separate conman install complicates this, and I haven't attempted to get ARM stuff working yet (and I don't have a ready test platform for it).

The existing remote-console Dockerfile had both build and runnable containers. Other OpenCHAMI services do not have build containers: they use goreleaser to build the service binary before copying it into the runnable container. This PR keeps the build containers (and adds non-Alpine targets for build and run) alongside the goreleaser target.

These can coexist, but we'll probably want to par down to only one eventually, to avoid maintaining multiple build paths. The fully containerized approach is nice for local development (it doesn't require a copy of goreleaser and allows easier pushes to alternative repos), but it doesn't have goreleaser's GitHub release management.

We should be able to handle local development workflows with goreleaser also, but we need to document how.