### PR TITLE
fix: use correct log dir bitmask

### DIFF
--- a/cmd/remote-console/main.go
+++ b/cmd/remote-console/main.go
@@ -76,7 +76,10 @@ func main() {
 	go console.WatchHardware()
 
 	// then we set up the goroutine that controls conman
-	console.EnsureDirPresent("/var/log/conman", 666)
+	_, err := console.EnsureDirPresent("/var/log/conman", 0755)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	// I am not sure that we need this, so I am leaving it out for
 	// now, I think that normal logging will work now that we only
@@ -141,7 +144,7 @@ func main() {
 
 	// Run the server
 	log.Printf("Info: Console API listening on: %s\n", svcHost)
-	err := server.ListenAndServe()
+	err = server.ListenAndServe()
 	if err != nil && err != http.ErrServerClosed {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This is a directory, it needs directory permissions.

While we have a chmod for this dir in the Dockerfile, we'll often mount a volume for the log dir. If that volume does not have a `conman` dir already, the service will fall back to creating the directory itself. The 666 permission resulted in:

```
nobody@rainest-console-test-f968d6c68-ps429:/go$ ls -l /var/log/conman/                     
ls: cannot open directory '/var/log/conman/': Permission denied
nobody@rainest-console-test-f968d6c68-ps429:/go$ ls -l /var/log/       
total 0
d-w---x--- 2 nobody nogroup 6 Jul 31 20:22 conman
drwxr-xr-x 2 nobody nogroup 6 Jul 31 20:22 conman.old
```
and created a phantom run as root requirement.

Also checks the error of the create attempt, because we can't properly start if we can't interact with that dir.