### PR TITLE
Remove used field

### DIFF
--- a/internal/console/health.go
+++ b/internal/console/health.go
@@ -18,7 +18,6 @@ import (
 // HealthResponse - used to report service health stats
 type HealthResponse struct {
 	NumberConsoles     string `json:"consoles"`
-	HardwareUpdateSec  string `json:"hardwareupdatesec"`
 	LastHardwareUpdate string `json:"hardwareupdate"`
 }
 


### PR DESCRIPTION
This field doesn't really belong in the status and is never set. It a configuration option, so is a little odd return in a status message anyway.