### PR TITLE
fix(console): report input dropped during reconnects

### DIFF
--- a/internal/console/conman_backend.go
+++ b/internal/console/conman_backend.go
@@ -8,45 +8,144 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
+	"math/rand/v2"
 	"os"
 	"os/exec"
 	"sync"
 	"syscall"
 	"time"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
 	"github.com/creack/pty"
 )
 
-// conmanConsoleIO implements consoleIO for IPMI nodes managed by conman.
-// It runs a goroutine that keeps a conman process alive, reconnecting automatically.
+const (
+	conmanOutputBufferDepth = 256
+	conmanReadBufferSize    = 4096
+	conmanReconnectMin      = time.Second
+	conmanReconnectMax      = 10 * time.Second
+	conmanStableConnection  = 30 * time.Second
+	conmanExitTimeout       = 100 * time.Millisecond
+	conmanTerminateTimeout  = time.Second
+)
+
+type conmanProcess struct {
+	nodeID string
+	cmd    *exec.Cmd
+	ptmx   *os.File
+	done   chan struct{}
+
+	stopOnce sync.Once
+}
+
+func launchConmanProcess(nodeID string) (*conmanProcess, error) {
+	return launchPTYProcess(nodeID, exec.Command("conman", nodeID))
+}
+
+func launchPTYProcess(nodeID string, cmd *exec.Cmd) (*conmanProcess, error) {
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		return nil, fmt.Errorf("start conman PTY: %w", err)
+	}
+
+	process := &conmanProcess{
+		nodeID: nodeID,
+		cmd:    cmd,
+		ptmx:   ptmx,
+		done:   make(chan struct{}),
+	}
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			slog.Debug("ConMan client exited", "nodeID", nodeID, "error", err)
+		}
+		close(process.done)
+	}()
+
+	return process, nil
+}
+
+func (p *conmanProcess) stop() {
+	p.stopOnce.Do(func() {
+		if p.ptmx != nil {
+			escapeDone := make(chan struct{})
+
+			// Send escape sequence to close the PTY
+			go func() {
+				_, _ = p.ptmx.Write([]byte("&."))
+				close(escapeDone)
+			}()
+			_ = waitForProcess(escapeDone, conmanExitTimeout)
+		}
+
+		// Wait for the process to finish
+		if waitForProcess(p.done, conmanExitTimeout) {
+			if p.ptmx != nil {
+				_ = p.ptmx.Close()
+			}
+			return
+		}
+
+		// If the process is still running, send SIGTERM
+		if p.cmd != nil && p.cmd.Process != nil {
+			_ = p.cmd.Process.Signal(syscall.SIGTERM)
+		}
+		if p.ptmx != nil {
+			_ = p.ptmx.Close()
+		}
+
+		if waitForProcess(p.done, conmanTerminateTimeout) {
+			return
+		}
+
+		// If the process is still running, send SIGKILL
+		if p.cmd != nil && p.cmd.Process != nil {
+			slog.Warn("ConMan client did not stop after SIGTERM, killing it", "nodeID", p.nodeID)
+			_ = p.cmd.Process.Kill()
+			_ = waitForProcess(p.done, conmanTerminateTimeout)
+		}
+	})
+}
+
+func waitForProcess(done <-chan struct{}, timeout time.Duration) bool {
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+
+	select {
+	case <-done:
+		return true
+	case <-timer.C:
+		return false
+	}
+}
+
+// conmanConsoleIO implements consoleIO for IPMI nodes managed by ConMan.
+// It keeps a ConMan client process alive while the node remains eligible.
 type conmanConsoleIO struct {
 	nodeID string
 
-	mu   sync.Mutex
-	cmd  *exec.Cmd
-	ptmx *os.File
+	mu      sync.Mutex
+	process *conmanProcess
 
-	out    chan []byte
-	ctx    context.Context
-	cancel context.CancelFunc
+	out     chan []byte
+	dropped int
+	ctx     context.Context
+	cancel  context.CancelFunc
 
 	closeOnce sync.Once
 }
 
-// newConmanConsoleIO creates and starts a conmanConsoleIO for nodeID.
+// newConmanConsoleIO creates and starts a ConMan backend for an IPMI node.
 func newConmanConsoleIO(nodeID string) (*conmanConsoleIO, error) {
-	if !nodes.IsCurrentNode(nodeID) {
-		return nil, fmt.Errorf("node %s is not a current node", nodeID)
+	if nodes.CurrentNode(nodeID) == nil {
+		return nil, fmt.Errorf("node %s is not current", nodeID)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	c := &conmanConsoleIO{
 		nodeID: nodeID,
-		out:    make(chan []byte, 256),
+		out:    make(chan []byte, conmanOutputBufferDepth),
 		ctx:    ctx,
 		cancel: cancel,
 	}
@@ -59,119 +158,148 @@ func newConmanConsoleIO(nodeID string) (*conmanConsoleIO, error) {
 func (c *conmanConsoleIO) run() {
 	defer close(c.out)
 
+	backoff := conmanReconnectMin
 	for {
-		select {
-		case <-c.ctx.Done():
+		if c.ctx.Err() != nil {
 			return
-		default:
 		}
 
-		if err := c.startProcess(); err != nil {
-			slog.Error("Failed to start conman process", "nodeID", c.nodeID, "error", err)
-			select {
-			case <-time.After(time.Second):
-			case <-c.ctx.Done():
+		// Check if the node is still current
+		if !c.nodeIsCurrent() {
+			slog.Info("Node is no longer managed by ConMan", "nodeID", c.nodeID)
+			return
+		}
+
+		// Start the process
+		started := time.Now()
+		process, err := c.startProcess()
+		if err != nil {
+			if errors.Is(err, context.Canceled) {
 				return
 			}
+
+			slog.Error("Failed to start conman process", "nodeID", c.nodeID, "error", err)
+			message := fmt.Sprintf("\n[Unable to start ConMan for %s. Retrying...]\n", c.nodeID)
+			if !c.queueOutput([]byte(message)) || !c.waitToReconnect(backoff) {
+				return
+			}
+			backoff = nextConmanBackoff(backoff)
 			continue
 		}
 
-		c.readLoop()
+		// Read until the PTY closes.
+		c.streamOutput(process)
+		// Remove the process from the backend.
+		c.clearProcess(process)
+		// Stop and reap the process.
+		process.stop()
 
-		// Process exited. Clean up.
-		c.mu.Lock()
-		c.ptmx = nil
-		c.cmd = nil
-		c.mu.Unlock()
-
-		// Notify the client and wait before reconnecting.
-		reconnectMsg := fmt.Sprintf("\n[Reconnecting to %s...]\n", c.nodeID)
-		select {
-		case c.out <- []byte(reconnectMsg):
-		case <-c.ctx.Done():
+		if c.ctx.Err() != nil {
+			return
+		}
+		if !c.nodeIsCurrent() {
+			slog.Info("Node is no longer managed by ConMan", "nodeID", c.nodeID)
 			return
 		}
 
-		select {
-		case <-time.After(time.Second):
-		case <-c.ctx.Done():
-			return
+		// Reset the backoff after a stable connection or increase it after an early exit.
+		delay := backoff
+		if time.Since(started) >= conmanStableConnection {
+			backoff = conmanReconnectMin
+			delay = backoff
+		} else {
+			backoff = nextConmanBackoff(backoff)
 		}
 
-		if !nodes.IsCurrentNode(c.nodeID) {
-			slog.Info("Node no longer in inventory, stopping conman backend", "nodeID", c.nodeID)
+		message := fmt.Sprintf("\n[Reconnecting to %s...]\n", c.nodeID)
+		if !c.queueOutput([]byte(message)) || !c.waitToReconnect(delay) {
 			return
 		}
 	}
 }
 
-// startProcess launches a new conman process with a PTY.
-func (c *conmanConsoleIO) startProcess() error {
-	select {
-	case <-c.ctx.Done():
-		return fmt.Errorf("context cancelled")
-	default:
+func (c *conmanConsoleIO) startProcess() (*conmanProcess, error) {
+	if c.ctx.Err() != nil {
+		return nil, context.Canceled
 	}
 
-	cmd := exec.Command("conman", c.nodeID)
-	ptmx, err := pty.Start(cmd)
+	process, err := launchConmanProcess(c.nodeID)
 	if err != nil {
-		return fmt.Errorf("pty.Start conman: %w", err)
+		return nil, err
 	}
 
 	c.mu.Lock()
-	c.cmd = cmd
-	c.ptmx = ptmx
+	if c.ctx.Err() != nil {
+		c.mu.Unlock()
+		process.stop()
+		return nil, context.Canceled
+	}
+	c.process = process
 	c.mu.Unlock()
 
-	// Reap the child process to prevent zombies.
-	go func() {
-		if err := cmd.Wait(); err != nil {
-			slog.Debug("conman process exited", "nodeID", c.nodeID, "error", err)
-		}
-	}()
-
-	return nil
+	return process, nil
 }
 
-// readLoop reads PTY output and sends it to the output channel.
-func (c *conmanConsoleIO) readLoop() {
-	buf := make([]byte, 4096)
+func (c *conmanConsoleIO) clearProcess(process *conmanProcess) {
+	c.mu.Lock()
+	if c.process == process {
+		c.process = nil
+	}
+	c.mu.Unlock()
+}
+
+func (c *conmanConsoleIO) currentProcess() *conmanProcess {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.process
+}
+
+func (c *conmanConsoleIO) nodeIsCurrent() bool {
+	return nodes.CurrentNode(c.nodeID) != nil
+}
+
+func (c *conmanConsoleIO) waitToReconnect(backoff time.Duration) bool {
+	timer := time.NewTimer(jitterConmanBackoff(backoff))
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return true
+	case <-c.ctx.Done():
+		return false
+	}
+}
+
+func nextConmanBackoff(current time.Duration) time.Duration {
+	if current >= conmanReconnectMax/2 {
+		return conmanReconnectMax
+	}
+	return current * 2
+}
+
+func jitterConmanBackoff(backoff time.Duration) time.Duration {
+	if backoff <= 0 {
+		return 0
+	}
+	return backoff/2 + time.Duration(rand.Int64N(int64(backoff/2)+1))
+}
+
+func (c *conmanConsoleIO) streamOutput(process *conmanProcess) {
+	buf := make([]byte, conmanReadBufferSize)
 	for {
-		select {
-		case <-c.ctx.Done():
-			return
-		default:
-		}
-
-		c.mu.Lock()
-		ptmx := c.ptmx
-		c.mu.Unlock()
-
-		if ptmx == nil {
-			return
-		}
-
-		ready, err := waitForPTYReadable(int(ptmx.Fd()), 250*time.Millisecond)
-		if err != nil {
-			return
-		}
-		if !ready {
-			continue
-		}
-
-		n, err := ptmx.Read(buf)
+		n, err := process.ptmx.Read(buf)
 		if n > 0 {
-			data := make([]byte, n)
-			copy(data, buf[:n])
-			select {
-			case c.out <- data:
-			case <-c.ctx.Done():
+			data := append([]byte(nil), buf[:n]...)
+			if !c.queueOutput(data) {
 				return
 			}
 		}
 		if err != nil {
-			if err.Error() != "EOF" && !isEIO(err) {
+			// EOF, EIO, and a closed PTY are expected during shutdown.
+			if c.ctx.Err() == nil &&
+				!errors.Is(err, io.EOF) &&
+				!errors.Is(err, os.ErrClosed) &&
+				!errors.Is(err, syscall.EIO) {
 				slog.Error("PTY read error", "nodeID", c.nodeID, "error", err)
 			}
 			return
@@ -179,63 +307,66 @@ func (c *conmanConsoleIO) readLoop() {
 	}
 }
 
+func (c *conmanConsoleIO) queueOutput(data []byte) bool {
+	if c.dropped > 0 {
+		notice := fmt.Appendf(nil, "\n[Console %s: %d bytes of output dropped, client not keeping up]\n",
+			c.nodeID, c.dropped)
+		select {
+		case c.out <- notice:
+			slog.Info("ConMan console client caught up after dropping output",
+				"nodeID", c.nodeID, "bytesDropped", c.dropped)
+			c.dropped = 0
+		case <-c.ctx.Done():
+			return false
+		default:
+			c.dropped += len(data)
+			return true
+		}
+	}
+
+	select {
+	case c.out <- data:
+		return true
+	case <-c.ctx.Done():
+		return false
+	default:
+		if c.dropped == 0 {
+			slog.Warn("ConMan console client not keeping up, dropping output", "nodeID", c.nodeID)
+		}
+		c.dropped += len(data)
+		return true
+	}
+}
+
 func (c *conmanConsoleIO) Output() <-chan []byte { return c.out }
 
 func (c *conmanConsoleIO) Write(p []byte) (int, error) {
-	c.mu.Lock()
-	ptmx := c.ptmx
-	c.mu.Unlock()
-
-	if ptmx == nil {
-		return len(p), nil // silent drop during reconnect
+	process := c.currentProcess()
+	if process == nil {
+		return 0, errNotConnected
 	}
-	return ptmx.Write(p)
+
+	n, err := process.ptmx.Write(p)
+	if err != nil {
+		return n, fmt.Errorf("%w: %w", errNotConnected, err)
+	}
+
+	return n, nil
 }
 
 func (c *conmanConsoleIO) Close() error {
 	c.closeOnce.Do(func() {
+		c.cancel()
+
 		c.mu.Lock()
-		ptmx := c.ptmx
-		cmd := c.cmd
+		process := c.process
+		c.process = nil
 		c.mu.Unlock()
 
-		if ptmx != nil {
-			// Send ConMan escape to gracefully disconnect.
-			_, _ = ptmx.Write([]byte("&."))
-			time.Sleep(100 * time.Millisecond)
-			_ = ptmx.Close()
+		if process != nil {
+			process.stop()
 		}
-		if cmd != nil && cmd.Process != nil {
-			_ = cmd.Process.Signal(syscall.SIGTERM)
-		}
-
-		c.cancel()
 	})
+
 	return nil
-}
-
-// isEIO checks if an error is EIO (expected when a PTY process exits).
-func isEIO(err error) bool {
-	var errno syscall.Errno
-	if errors.As(err, &errno) {
-		return errno == syscall.EIO
-	}
-	return false
-}
-
-// waitForPTYReadable waits until the PTY fd is readable or the timeout elapses.
-func waitForPTYReadable(fd int, timeout time.Duration) (bool, error) {
-	var readSet unix.FdSet
-	readSet.Zero()
-	readSet.Set(fd)
-
-	tv := unix.NsecToTimeval(timeout.Nanoseconds())
-	n, err := unix.Select(fd+1, &readSet, nil, nil, &tv)
-	if err != nil {
-		if errors.Is(err, syscall.EINTR) {
-			return false, nil
-		}
-		return false, err
-	}
-	return n > 0, nil
 }

--- a/internal/console/consoleio.go
+++ b/internal/console/consoleio.go
@@ -4,14 +4,18 @@
 
 package console
 
-// consoleIO abstracts the underlying console backend (PTY/conman or SSH).
-// Implementations handle reconnection internally; Output() is closed only on
-// permanent shutdown (context cancelled or node removed from inventory).
+import "errors"
+
+// errNotConnected means the backend is temporarily disconnected.
+// Callers should drop the input and keep the session open while it reconnects.
+var errNotConnected = errors.New("console backend not connected")
+
+// consoleIO provides I/O for PTY, conman, and SSH backends.
 type consoleIO interface {
-	// Output returns a channel of console output chunks. The channel is closed
-	// when the backend shuts down permanently.
+	// Output returns console output and closes on permanent shutdown.
 	Output() <-chan []byte
-	// Write sends data to the console (user input).
+	// Write sends input to the console. It returns errNotConnected without
+	// writing while reconnecting. Check wrapped errors with errors.Is.
 	Write(p []byte) (n int, err error)
 	// Close shuts down the backend. Safe to call multiple times.
 	Close() error

--- a/internal/console/interactive.go
+++ b/internal/console/interactive.go
@@ -6,6 +6,7 @@ package console
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -161,9 +162,15 @@ func (s *interactiveConsoleSession) streamInput(ctx context.Context) {
 		}
 
 		if messageType == websocket.TextMessage || messageType == websocket.BinaryMessage {
-			// Both backends return len(p), nil when disconnected (silent drop),
-			// so write errors here indicate a genuine problem worth logging.
 			if _, err := s.io.Write(message); err != nil {
+				if errors.Is(err, errNotConnected) {
+					// The backend is between connections. Discard the input and
+					// keep the client attached — it reconnects on its own, and
+					// the client sees the reconnect marker on the output stream.
+					slog.Debug("Dropped console input, backend not connected",
+						"nodeID", s.nodeID, "bytes", len(message))
+					continue
+				}
 				slog.Error("Failed to write to console backend", "nodeID", s.nodeID, "error", err)
 				s.closeWithReason(sessionCloseError, "failed to write to console")
 				return
@@ -201,6 +208,29 @@ func newInteractiveConsoleSession(nodeID string, conn *websocket.Conn, cio conso
 	return session
 }
 
+// newConsoleIO selects the SSH or ConMan backend for a node.
+func newConsoleIO(node *nodes.NodeConsoleInfo, sshMgr *ssh.SSHConsoleManager) (consoleIO, error) {
+	switch node.ConnectionType {
+	case nodes.SSH:
+		cio, err := newSSHConsoleIO(node.ID, sshMgr)
+		if err != nil {
+			return nil, err
+		}
+		return cio, nil
+
+	case nodes.IPMI:
+		cio, err := newConmanConsoleIO(node.ID)
+		if err != nil {
+			return nil, err
+		}
+		return cio, nil
+
+	default:
+		return nil, fmt.Errorf("unsupported console connection type %q for node %s",
+			node.ConnectionType, node.ID)
+	}
+}
+
 func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, r *http.Request, sshMgr *ssh.SSHConsoleManager) {
 	// Make sure the request is cleaned up
 	defer drainAndCloseRequestBody(r)
@@ -212,7 +242,7 @@ func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, 
 	}
 
 	// Make sure we are monitoring a valid node
-	node := nodes.CurrentNodes()[nodeID]
+	node := nodes.CurrentNode(nodeID)
 	if node == nil {
 		http.Error(w, "Node doesn't exist", http.StatusNotFound)
 		return
@@ -236,17 +266,15 @@ func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, 
 	}
 
 	// From here on, errors must be sent via WebSocket close frames
-	var cio consoleIO
-	if useSSH {
-		cio, err = newSSHConsoleIO(nodeID, sshMgr)
-	} else {
-		cio, err = newConmanConsoleIO(nodeID)
-	}
+	cio, err := newConsoleIO(node, sshMgr)
 	if err != nil {
 		slog.Error("Failed to create console IO backend", "nodeID", nodeID, "error", err)
 		_ = conn.WriteMessage(websocket.CloseMessage,
 			websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "failed to connect to console"))
-		_ = conn.Close()
+		if closeErr := conn.Close(); closeErr != nil {
+			slog.Debug("Failed to close WebSocket after backend error",
+				"nodeID", nodeID, "error", closeErr)
+		}
 		return
 	}
 

--- a/internal/console/ssh_backend.go
+++ b/internal/console/ssh_backend.go
@@ -5,6 +5,7 @@
 package console
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -20,7 +21,7 @@ func generateClientID() string {
 	return strconv.FormatUint(clientIDCounter.Add(1), 10)
 }
 
-// sshConsoleIO implements consoleIO backed by an SSHConsoleNode attachment.
+// sshConsoleIO implements consoleIO backed by an SSHConsole attachment.
 type sshConsoleIO struct {
 	nodeID    string
 	clientID  string
@@ -46,7 +47,15 @@ func newSSHConsoleIO(nodeID string, manager *ssh.SSHConsoleManager) (*sshConsole
 func (s *sshConsoleIO) Output() <-chan []byte { return s.out }
 
 func (s *sshConsoleIO) Write(p []byte) (int, error) {
-	return s.manager.Write(s.nodeID, p)
+	n, err := s.manager.Write(s.nodeID, p)
+	if errors.Is(err, ssh.ErrNotConnected) {
+		// Restate the manager's sentinel as the consoleIO one so the session
+		// loop can recognise it without knowing which backend it holds. Wrapping
+		// still lets errors.Is find ssh.ErrNotConnected and keeps the
+		// backend-specific detail.
+		return n, fmt.Errorf("%w: %w", errNotConnected, err)
+	}
+	return n, err
 }
 
 func (s *sshConsoleIO) Close() error {

--- a/internal/console/tail.go
+++ b/internal/console/tail.go
@@ -298,7 +298,7 @@ func doTailConsole(consoleLogsPath string, w http.ResponseWriter, r *http.Reques
 	slog.Info("Tailing console for node", "nodeID", nodeID)
 
 	// Make sure we are monitoring a valid node
-	if exists := nodes.IsCurrentNode(nodeID); !exists {
+	if nodes.CurrentNode(nodeID) == nil {
 		http.Error(w, "Node not found", http.StatusNotFound)
 		return
 	}

--- a/internal/nodes/nodes.go
+++ b/internal/nodes/nodes.go
@@ -7,7 +7,6 @@ package nodes
 
 // Package nodes manages node discovery and state from HSM
 
-
 import (
 	"context"
 	"encoding/json"
@@ -326,12 +325,17 @@ func CurrentNodes() map[string]*NodeConsoleInfo {
 	return nodesCopy
 }
 
-func IsCurrentNode(nodeID string) bool {
+func CurrentNode(nodeID string) *NodeConsoleInfo {
 	currNodesMutex.Lock()
 	defer currNodesMutex.Unlock()
 
-	_, ok := currentNodes[nodeID]
-	return ok
+	node := currentNodes[nodeID]
+	if node == nil {
+		return nil
+	}
+	nodeCopy := *node
+
+	return &nodeCopy
 }
 
 func GetHardwareUpdateTime() string {

--- a/internal/nodes/nodes_test.go
+++ b/internal/nodes/nodes_test.go
@@ -156,3 +156,21 @@ func TestUpdateNodesNoChange(t *testing.T) {
 	require.Contains(t, currentNodes, "x0c0s1b0")
 	require.Contains(t, currentNodes, "x0c0s1b1")
 }
+
+func TestCurrentNode(t *testing.T) {
+	resetCurrentNodes()
+	t.Cleanup(resetCurrentNodes)
+
+	updateNodes([]NodeConsoleInfo{
+		{ID: "ipmi", ConnectionType: IPMI},
+		{ID: "ssh", ConnectionType: SSH},
+	})
+
+	node := CurrentNode("ipmi")
+	require.NotNil(t, node)
+	require.Equal(t, IPMI, node.ConnectionType)
+	require.Nil(t, CurrentNode("missing"))
+
+	node.ConnectionType = SSH
+	require.Equal(t, IPMI, CurrentNode("ipmi").ConnectionType)
+}

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -6,6 +6,7 @@ package ssh
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"path/filepath"
@@ -16,6 +17,13 @@ import (
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
 )
 
+// ErrNotConnected is returned by Write when the node exists but its SSH
+// session is currently down — during the initial connect, or between a drop
+// and the next retry. The input is discarded. It is deliberately distinct from
+// the "node not found" error: not-found is permanent and worth failing on,
+// whereas this clears on its own once the node reconnects.
+var ErrNotConnected = errors.New("ssh console node not connected")
+
 // SSHConsoleManager manages the set of active SSHConsoleNodes.
 type SSHConsoleManager struct {
 	cfg      SSHConfig
@@ -24,10 +32,10 @@ type SSHConsoleManager struct {
 
 	// nodesMu protects the nodes map.
 	// Lock ordering: nodesMu → clientsMu, nodesMu → connMu
-	nodesMu    sync.RWMutex
-	nodes map[string]*SSHConsoleNode
+	nodesMu sync.RWMutex
+	nodes   map[string]*SSHConsoleNode
 	// cancels maps nodeID to the cancel func for that node's Run goroutine.
-	cancels    map[string]context.CancelFunc
+	cancels map[string]context.CancelFunc
 }
 
 // NewSSHConsoleManager creates a new manager. keyPath is the SSH private key
@@ -35,11 +43,11 @@ type SSHConsoleManager struct {
 // where per-node console log files are written.
 func NewSSHConsoleManager(cfg SSHConfig, keyPath, logsPath string) *SSHConsoleManager {
 	return &SSHConsoleManager{
-		cfg:         cfg,
-		keyPath:     keyPath,
-		logsPath:    logsPath,
-		nodes: make(map[string]*SSHConsoleNode),
-		cancels:     make(map[string]context.CancelFunc),
+		cfg:      cfg,
+		keyPath:  keyPath,
+		logsPath: logsPath,
+		nodes:    make(map[string]*SSHConsoleNode),
+		cancels:  make(map[string]context.CancelFunc),
 	}
 }
 
@@ -176,7 +184,9 @@ func (m *SSHConsoleManager) Detach(nodeID, clientID string) {
 	}
 }
 
-// Write sends data to the SSH session stdin for a node.
+// Write sends data to the SSH session stdin for a node. It returns an error if
+// the node is not managed by this manager, and ErrNotConnected if it is managed
+// but currently disconnected.
 func (m *SSHConsoleManager) Write(nodeID string, p []byte) (int, error) {
 	m.nodesMu.RLock()
 	node, ok := m.nodes[nodeID]

--- a/internal/ssh/node.go
+++ b/internal/ssh/node.go
@@ -64,7 +64,7 @@ type SSHConsoleNode struct {
 
 	// logFile is opened at the start of Run and written only from the Run goroutine.
 	logFile     *os.File
-	logPath     string    // logsPath + "/console." + nodeID
+	logPath     string        // logsPath + "/console." + nodeID
 	reopenLogCh chan struct{} // buffered depth-1; signals broadcast to reopen after rotation
 
 	// cancel is called by the manager to stop the Run goroutine.
@@ -135,8 +135,8 @@ func (n *SSHConsoleNode) connectAndStream(ctx context.Context) bool {
 	n.streamStdout(stdout)
 
 	// Clean up the connection. Nil stdin under connMu so Write sees nil and
-	// drops silently, then close it under stdinMu so an in-flight Write cannot
-	// race with Close on the underlying SSH channel buffer.
+	// reports ErrNotConnected, then close it under stdinMu so an in-flight Write
+	// cannot race with Close on the underlying SSH channel buffer.
 	n.connMu.Lock()
 	if n.sshClient != nil {
 		_ = n.sshClient.Close()
@@ -558,8 +558,10 @@ func (n *SSHConsoleNode) Detach(clientID string) {
 	}
 }
 
-// Write sends data to the SSH session's stdin. Returns len(p), nil silently
-// when disconnected so callers do not treat transient disconnects as fatal.
+// Write sends data to the SSH session's stdin. It reports ErrNotConnected
+// rather than claiming a successful write when the node is between
+// connections, so callers can decide what to do with the discarded input; a
+// transient disconnect is not a reason to tear the caller down.
 func (n *SSHConsoleNode) Write(p []byte) (int, error) {
 	n.stdinMu.Lock()
 	defer n.stdinMu.Unlock()
@@ -569,7 +571,7 @@ func (n *SSHConsoleNode) Write(p []byte) (int, error) {
 	n.connMu.Unlock()
 
 	if stdin == nil {
-		return len(p), nil // silent drop during reconnect
+		return 0, ErrNotConnected
 	}
 	return stdin.Write(p)
 }


### PR DESCRIPTION
Return a transient error when either backend cannot deliver console
input, allowing the client session to stay attached. Bound ConMan client
process cleanup and make its output path safe for slow consumers.

Signed-off-by: Chris Harris <cjh@lbl.gov>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>