### PR TITLE
feat(ssh): apply inventory without credential reads

### DIFF
--- a/cmd/remote-console/service.go
+++ b/cmd/remote-console/service.go
@@ -51,12 +51,14 @@ type LogsService interface {
 	AggregateFiles(consoleLogsPath string, nodes map[string]*nodes.NodeConsoleInfo)
 }
 
-// SSHConsoleService defines the management interface for the SSH console manager.
-// Interactive access (Attach/Detach/Write) flows through the console.SSHManager
-// interface, which is passed directly to console.SetupRoutes.
+// SSHConsoleService defines the management interface for the SSH console
+// manager. Interactive access (Attach/Detach/Write) does not go through here —
+// the concrete *ssh.SSHConsoleManager is passed to console.SetupRoutes, which
+// uses it directly.
 type SSHConsoleService interface {
-	UpdateNodes(ctx context.Context, sshNodes map[string]*nodes.NodeConsoleInfo,
+	UpdateNodesAndCredentials(ctx context.Context, sshNodes map[string]*nodes.NodeConsoleInfo,
 		passwords map[string]compcreds.CompCredentials) error
+	UpdateNodes(ctx context.Context, sshNodes map[string]*nodes.NodeConsoleInfo) error
 	UpdateCredentials(passwords map[string]compcreds.CompCredentials)
 	ReopenLogs()
 }
@@ -116,14 +118,33 @@ func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpC
 				currentNodes := nodes.CurrentNodes()
 				passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(currentNodes), 15, 10)
 				if err != nil {
-					slog.Error("Failed to fetch credentials for updated nodes", "error", err)
+					// passwords holds whatever the final attempt returned: possibly
+					// nil, possibly a partial map. An absent entry is then
+					// indistinguishable from a node that legitimately has no password
+					// and uses key auth, so neither consumer can read this map as the
+					// full picture.
+					//
+					// Skip the conman reconfigure — it interpolates credentials
+					// straight into conman.conf, and rewriting that from a partial map
+					// before SignalConmanTERM would drop working IPMI consoles. Apply
+					// the SSH node changes without credentials, so removed nodes
+					// still stop and added nodes still start while every existing
+					// node keeps the credentials it already has.
+					//
+					// This only catches the failed fetch. A fetch that exhausts its
+					// retries and returns a partial map with a nil error takes the
+					// branch below and reconfigures from incomplete credentials.
+					slog.Error("Failed to fetch credentials for updated nodes; skipping conman reconfigure, applying SSH node changes without credentials", "error", err)
+					if err := sshService.UpdateNodes(ctx, filterSSHNodes(currentNodes)); err != nil {
+						slog.Error("Failed to update SSH console nodes", "error", err)
+					}
 				} else {
 					// Regenerate conman config with the new node list and credentials.
 					if _, err := conmanService.ConfigureConman(filterIPMINodes(currentNodes), passwords); err != nil {
 						slog.Error("Failed to reconfigure conman", "error", err)
 					}
-					// Update SSH nodes with current topology and credentials.
-					if err := sshService.UpdateNodes(ctx, filterSSHNodes(currentNodes), passwords); err != nil {
+					// Update SSH nodes with the current node set and credentials.
+					if err := sshService.UpdateNodesAndCredentials(ctx, filterSSHNodes(currentNodes), passwords); err != nil {
 						slog.Error("Failed to update SSH console manager", "error", err)
 					}
 				}
@@ -170,6 +191,11 @@ func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig,
 				currentNodes := nodes.CurrentNodes()
 				passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(currentNodes), 3, 5)
 				if err != nil {
+					// Same partial-map ambiguity as the node watch loop, but here
+					// skipping outright is the whole answer: no node joined or left,
+					// so there is no node change to apply and every node keeps
+					// running on the credentials it already has until a later fetch
+					// succeeds.
 					slog.Error("Failed to fetch updated credentials", "error", err)
 				} else {
 					// Regenerate conman config so IPMI nodes pick up the new credentials.
@@ -370,9 +396,16 @@ func runService(config remoteConsoleConfig) error {
 	initialSSHNodes := filterSSHNodes(nodes.CurrentNodes())
 	if len(initialSSHNodes) > 0 {
 		initialXNames := filterXNames(initialSSHNodes)
-		if passwords, err := credsService.GetPasswordsWithRetries(serviceCtx, initialXNames, 15, 10); err != nil {
-			slog.Warn("Failed to fetch initial SSH credentials", "error", err)
-		} else if err := sshManager.UpdateNodes(serviceCtx, initialSSHNodes, passwords); err != nil {
+		passwords, err := credsService.GetPasswordsWithRetries(serviceCtx, initialXNames, 15, 10)
+		if err != nil {
+			// Start the nodes anyway. watchForNodesUpdates only reconfigures when
+			// inventory actually changes, so bailing out here would leave every
+			// SSH console dead until something in SMD happened to change.
+			slog.Warn("Failed to fetch initial SSH credentials, starting nodes without them", "error", err)
+			if err := sshManager.UpdateNodes(serviceCtx, initialSSHNodes); err != nil {
+				slog.Error("Failed initial SSH node update", "error", err)
+			}
+		} else if err := sshManager.UpdateNodesAndCredentials(serviceCtx, initialSSHNodes, passwords); err != nil {
 			slog.Error("Failed initial SSH manager node update", "error", err)
 		}
 	}

--- a/internal/ssh/concurrent_test.go
+++ b/internal/ssh/concurrent_test.go
@@ -34,7 +34,7 @@ import (
 //	                (stresses connMu)
 //	credsWorker   – UpdateCredentials in a tight loop (stresses credsMu + connMu)
 //	rotateWorker  – ReopenLogs repeatedly (stresses reopenLogCh vs broadcast)
-//	updateWorker  – UpdateNodes with a shifting node set (stresses nodesMu vs
+//	updateWorker  – UpdateNodesAndCredentials with a shifting node set (stresses nodesMu vs
 //	                everything else)
 const (
 	concurrentNodes    = 100
@@ -82,8 +82,8 @@ func TestSSHConsoleManagerConcurrent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
-		t.Fatalf("initial UpdateNodes: %v", err)
+	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
+		t.Fatalf("initial UpdateNodesAndCredentials: %v", err)
 	}
 
 	// Wait until all nodes are registered (Attach succeeds) before starting workers.
@@ -213,14 +213,14 @@ func TestSSHConsoleManagerConcurrent(t *testing.T) {
 				}
 			}
 			subMap := makeNodeMap(subset)
-			if err := manager.UpdateNodes(ctx, subMap, makePasswords(subset)); err != nil {
-				t.Errorf("UpdateNodes (subset): %v", err)
+			if err := manager.UpdateNodesAndCredentials(ctx, subMap, makePasswords(subset)); err != nil {
+				t.Errorf("UpdateNodesAndCredentials (subset): %v", err)
 			}
 			time.Sleep(20 * time.Millisecond)
 
 			// Restore the full set.
-			if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
-				t.Errorf("UpdateNodes (full): %v", err)
+			if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
+				t.Errorf("UpdateNodesAndCredentials (full): %v", err)
 			}
 			time.Sleep(20 * time.Millisecond)
 		}

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -36,11 +36,14 @@ type SSHConsoleManager struct {
 	nodes   map[string]*SSHConsoleNode
 	// cancels maps nodeID to the cancel func for that node's Run goroutine.
 	cancels map[string]context.CancelFunc
+	running sync.WaitGroup
 }
 
-// NewSSHConsoleManager creates a new manager. keyPath is the SSH private key
-// path (may be empty if all nodes use password auth). logsPath is the directory
-// where per-node console log files are written.
+// NewSSHConsoleManager creates a new manager. cfg should be built from
+// DefaultSSHConfig and checked with cfg.Validate; the manager does not correct
+// bad values. keyPath is the SSH private key path (may be empty if all nodes
+// use password auth). logsPath is the directory where per-node console log
+// files are written.
 func NewSSHConsoleManager(cfg SSHConfig, keyPath, logsPath string) *SSHConsoleManager {
 	return &SSHConsoleManager{
 		cfg:      cfg,
@@ -49,6 +52,12 @@ func NewSSHConsoleManager(cfg SSHConfig, keyPath, logsPath string) *SSHConsoleMa
 		nodes:    make(map[string]*SSHConsoleNode),
 		cancels:  make(map[string]context.CancelFunc),
 	}
+}
+
+// Wait blocks until all console goroutines have stopped. The caller must first
+// cancel the context passed to UpdateNodes or remove every managed node.
+func (m *SSHConsoleManager) Wait() {
+	m.running.Wait()
 }
 
 // logPath returns the log file path for a node.
@@ -68,15 +77,56 @@ func credsChanged(a, b compcredentials.CompCredentials) bool {
 	return a.Username != b.Username || a.Password != b.Password
 }
 
-// UpdateNodes diffs the provided SSH node map against the currently active set.
-// New nodes are started, removed nodes are cancelled, changed nodes are restarted,
-// and nodes with only credential changes get UpdateCreds called.
+// UpdateNodes diffs the provided SSH node map against the currently active set:
+// new nodes are started, removed nodes are cancelled, and nodes whose
+// connection parameters changed are restarted. Every node that survives the
+// diff keeps the credentials it is already using.
+//
 // ctx must be the long-lived service context — node goroutines run until it is
 // cancelled or the node is explicitly stopped.
+//
+// This is the operation for a caller that could not obtain a complete set of
+// credentials, because an absent entry in a passwords map is ambiguous: it
+// means "use key auth" for a node with no Vault entry, but it also means
+// "Vault did not answer for this node this time", since
+// GetPasswordsWithRetries returns a partial map with a nil error once it
+// exhausts its retries. Leaving auth alone keeps working nodes working while
+// the membership change still takes effect.
+//
+// Nodes discovered here start with no password and therefore attempt key auth.
+// If they are really password nodes they will fail and back off until a later
+// successful fetch reaches them through UpdateCredentials.
 func (m *SSHConsoleManager) UpdateNodes(
 	ctx context.Context,
 	sshNodes map[string]*nodes.NodeConsoleInfo,
+) error {
+	return m.update(ctx, sshNodes, nil, false)
+}
+
+// UpdateNodesAndCredentials does everything UpdateNodes does, and additionally
+// applies passwords: a node whose credentials changed gets UpdateCreds called,
+// which reconnects it under the new ones.
+//
+// passwords is taken as authoritative — a nodeID absent from it means that node
+// has no stored password and should authenticate with the configured SSH key
+// (see buildAuth). Only call this when the credential fetch succeeded. A
+// partial map from a failed fetch would strip working password nodes down to
+// key auth; use UpdateNodes for that case.
+func (m *SSHConsoleManager) UpdateNodesAndCredentials(
+	ctx context.Context,
+	sshNodes map[string]*nodes.NodeConsoleInfo,
 	passwords map[string]compcredentials.CompCredentials,
+) error {
+	return m.update(ctx, sshNodes, passwords, true)
+}
+
+// update is the shared implementation. When applyCreds is false, passwords is
+// ignored for nodes that already exist and their current credentials are kept.
+func (m *SSHConsoleManager) update(
+	ctx context.Context,
+	sshNodes map[string]*nodes.NodeConsoleInfo,
+	passwords map[string]compcredentials.CompCredentials,
+	applyCreds bool,
 ) error {
 	m.nodesMu.Lock()
 	defer m.nodesMu.Unlock()
@@ -92,24 +142,29 @@ func (m *SSHConsoleManager) UpdateNodes(
 	}
 
 	for nodeID, info := range sshNodes {
+		// An absent entry is an empty password, which buildAuth resolves to key
+		// auth. That is only a safe reading when the caller vouched for the map.
 		creds := passwords[nodeID]
 
 		existing, exists := m.nodes[nodeID]
 		if !exists {
-			// New node.
 			m.startNode(ctx, nodeID, info, creds)
 			continue
 		}
 
 		if nodeChanged(existing.info, info) {
-			// Connection parameters changed — restart.
+			// Connection parameters changed — restart. Keep the credentials the
+			// node already has when this update is not allowed to set them.
 			slog.Info("SSH console node parameters changed, restarting", "nodeID", nodeID)
+			if !applyCreds {
+				creds = existing.currentCreds()
+			}
 			m.cancels[nodeID]()
 			m.startNode(ctx, nodeID, info, creds)
 			continue
 		}
 
-		if credsChanged(existing.creds, creds) {
+		if applyCreds && credsChanged(existing.currentCreds(), creds) {
 			// Credentials only — reconnect in place without full restart.
 			slog.Info("SSH console node credentials changed, reconnecting", "nodeID", nodeID)
 			existing.UpdateCreds(creds)
@@ -127,11 +182,15 @@ func (m *SSHConsoleManager) startNode(ctx context.Context, nodeID string, info *
 	m.nodes[nodeID] = node
 	m.cancels[nodeID] = nodeCancel
 	slog.Info("Starting SSH console node", "nodeID", nodeID, "host", info.ConnectionHost)
-	go node.Run(nodeCtx)
+	m.running.Add(1)
+	go func() {
+		defer m.running.Done()
+		node.Run(nodeCtx)
+	}()
 }
 
 // UpdateCredentials updates credentials for nodes whose passwords have changed.
-// Nodes that changed connection info should use UpdateNodes instead.
+// Nodes that changed connection info should use UpdateNodesAndCredentials instead.
 func (m *SSHConsoleManager) UpdateCredentials(passwords map[string]compcredentials.CompCredentials) {
 	m.nodesMu.RLock()
 	type pending struct {
@@ -141,7 +200,7 @@ func (m *SSHConsoleManager) UpdateCredentials(passwords map[string]compcredentia
 	var updates []pending
 	for nodeID, node := range m.nodes {
 		if creds, ok := passwords[nodeID]; ok {
-			if credsChanged(node.creds, creds) {
+			if credsChanged(node.currentCreds(), creds) {
 				updates = append(updates, pending{node, creds})
 			}
 		}

--- a/internal/ssh/manager_test.go
+++ b/internal/ssh/manager_test.go
@@ -1,0 +1,212 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package ssh_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	compcredentials "github.com/Cray-HPE/hms-compcredentials"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/OpenCHAMI/remote-console/internal/nodes"
+	"github.com/OpenCHAMI/remote-console/internal/ssh"
+)
+
+// deadAddr returns a host:port that nothing is listening on, so connects to it
+// are refused immediately.
+func deadAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return addr
+}
+
+// TestWriteWhileDisconnectedReportsNotConnected pins the Write contract. A
+// managed node that has no live session must say so instead of returning
+// len(p), nil — that claimed the input had been delivered when it had been
+// thrown away, and the interactive session had no way to tell the difference.
+// The error is distinct from the not-found error because a caller should keep
+// going through a reconnect but not through a node that no longer exists.
+func TestWriteWhileDisconnectedReportsNotConnected(t *testing.T) {
+	id, nodeMap, passwords := singleNode(t, deadAddr(t))
+
+	manager := newManager(t, t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
+		t.Fatal(err)
+	}
+
+	n, err := manager.Write(id, []byte("into the void\n"))
+	if !errors.Is(err, ssh.ErrNotConnected) {
+		t.Fatalf("Write to a disconnected node = (%d, %v), want ErrNotConnected", n, err)
+	}
+	if n != 0 {
+		t.Errorf("Write to a disconnected node reported %d bytes written, want 0", n)
+	}
+
+	if _, err := manager.Write("no-such-node", []byte("x")); err == nil {
+		t.Fatal("Write to an unknown node succeeded")
+	} else if errors.Is(err, ssh.ErrNotConnected) {
+		t.Error("Write to an unknown node returned ErrNotConnected; a missing node is permanent, not a reconnect")
+	}
+}
+
+// waitForBytes reads from a session's recv channel until want appears or the
+// timeout expires.
+func waitForBytes(t *testing.T, sess *sshSession, want string, timeout time.Duration) {
+	t.Helper()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	var got strings.Builder
+	for {
+		select {
+		case data := <-sess.recv:
+			got.Write(data)
+			if strings.Contains(got.String(), want) {
+				return
+			}
+		case <-timer.C:
+			t.Fatalf("timeout waiting for %q on session; got %q", want, got.String())
+		}
+	}
+}
+
+// TestUpdateNodesPreservesCredentials covers the case where the service's
+// credential fetch failed and it falls back to a credential-preserving
+// update. A
+// healthy node must keep running on the credentials it already has. Applying
+// the empty password would trigger UpdateCreds, drop the connection, and then
+// fall through to key auth, which is not what this node uses.
+func TestUpdateNodesPreservesCredentials(t *testing.T) {
+	sessionCh := make(chan *sshSession)
+	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
+	id, nodeMap, passwords := singleNode(t, srv.addr())
+
+	manager := newManager(t, t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
+		t.Fatal(err)
+	}
+
+	// Attach before the first connect completes. node.Write silently drops and
+	// reports success while stdin is nil, so writing before the node is fully
+	// wired up would race; the connected marker is broadcast after stdin is
+	// set, which makes it a reliable sync point.
+	clientCh, err := manager.Attach(id, "creds-client")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Detach(id, "creds-client")
+
+	sess := <-sessionCh
+	waitForMarker(t, clientCh, "[Console "+id+" connected at", 15*time.Second)
+
+	if _, err := manager.Write(id, []byte("before\n")); err != nil {
+		t.Fatalf("write before update: %v", err)
+	}
+	waitForBytes(t, sess, "before", 15*time.Second)
+
+	// Same node set, credentials incomplete — what the service does when the
+	// fetch fails.
+	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
+		t.Fatal(err)
+	}
+
+	// The original session must still be live. If the credentials had been
+	// cleared, UpdateCreds would have torn this connection down.
+	select {
+	case <-sessionCh:
+		t.Fatal("node reconnected after a credential-preserving update; existing credentials were not preserved")
+	case <-time.After(2 * time.Second):
+	}
+
+	if _, err := manager.Write(id, []byte("after\n")); err != nil {
+		t.Fatalf("write after update: %v", err)
+	}
+	waitForBytes(t, sess, "after", 15*time.Second)
+}
+
+// TestUpdateNodesAddsAndRemovesNodes verifies that a credential-preserving update
+// still adds and removes nodes. Before this, a failed credential fetch skipped
+// the SSH update entirely, so a node removed from inventory kept its console
+// running and a newly added node never started.
+func TestUpdateNodesAddsAndRemovesNodes(t *testing.T) {
+	srv := newSSHServer(t, func(ch gossh.Channel) { _ = ch.Close() })
+	id, nodeMap, _ := singleNode(t, srv.addr())
+
+	manager := newManager(t, t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Add. The node must be registered so a later UpdateCredentials can reach it.
+	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Attach(id, "probe"); err != nil {
+		t.Fatalf("node was not registered by a credential-preserving update: %v", err)
+	}
+	manager.Detach(id, "probe")
+
+	// Remove.
+	if err := manager.UpdateNodes(ctx, map[string]*nodes.NodeConsoleInfo{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Attach(id, "probe"); err == nil {
+		t.Fatal("node still registered after removal via a credential-less update")
+	}
+}
+
+// TestUpdateNodesAndCredentialsAbsentPassword pins the other half of the
+// contract. When the caller vouches for the passwords map, a nodeID absent from
+// it means the node has no stored password and should fall through to key auth
+// (buildAuth). UpdateNodesAndCredentials must therefore apply the empty credentials and
+// reconnect, rather than assuming the entry was merely missing.
+func TestUpdateNodesAndCredentialsAbsentPassword(t *testing.T) {
+	sessionCh := make(chan *sshSession)
+	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
+	id, nodeMap, passwords := singleNode(t, srv.addr())
+
+	manager := newManager(t, t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
+		t.Fatal(err)
+	}
+
+	clientCh, err := manager.Attach(id, "keyauth-client")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Detach(id, "keyauth-client")
+
+	<-sessionCh
+	waitForMarker(t, clientCh, "[Console "+id+" connected at", 15*time.Second)
+
+	// Authoritative update that no longer carries a password for this node.
+	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, map[string]compcredentials.CompCredentials{}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The connection must be torn down so the node can re-authenticate. This
+	// manager has no key path, so the retry then fails and backs off — the
+	// disconnect itself is what proves the credentials were applied.
+	waitForMarker(t, clientCh, "[Console "+id+" disconnected at", 15*time.Second)
+}

--- a/internal/ssh/node.go
+++ b/internal/ssh/node.go
@@ -177,8 +177,8 @@ func jitter(d time.Duration) time.Duration {
 // when the node leaves inventory, which makes the manager the single authority
 // on node lifetime. Run must not decide to stop on its own: the manager would
 // keep the node in its map with no goroutine behind it, so Attach would hand
-// back a channel that never delivers and no later UpdateNodes would revive it
-// (the node still "exists" and its parameters are unchanged).
+// back a channel that never delivers and no later update would revive it (the
+// node still "exists" and its parameters are unchanged).
 func (n *SSHConsoleNode) Run(ctx context.Context) {
 	var err error
 	n.logFile, err = os.OpenFile(n.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)

--- a/internal/ssh/node_test.go
+++ b/internal/ssh/node_test.go
@@ -34,7 +34,7 @@ func TestSSHConsoleNodeReconnect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
+	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
 		t.Fatal(err)
 	}
 
@@ -75,7 +75,7 @@ func TestSSHConsoleNodeFanOut(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
+	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
 		t.Fatal(err)
 	}
 
@@ -145,7 +145,7 @@ func TestSSHConsoleNodeDataFlow(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
+	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
 		t.Fatal(err)
 	}
 
@@ -185,11 +185,12 @@ func TestSSHConsoleNodeDataFlow(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// 4. Node lifecycle via UpdateNodes
+// 4. Node lifecycle via UpdateNodesAndCredentials
 // ---------------------------------------------------------------------------
 
-// TestSSHConsoleNodeLifecycle verifies that removing a node via UpdateNodes
-// cancels its Run goroutine and that all associated goroutines exit cleanly.
+// TestSSHConsoleNodeLifecycle verifies that removing a node via
+// UpdateNodesAndCredentials cancels its Run goroutine and that all associated
+// goroutines exit cleanly.
 func TestSSHConsoleNodeLifecycle(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
@@ -201,7 +202,7 @@ func TestSSHConsoleNodeLifecycle(t *testing.T) {
 
 	goroutinesBefore := runtime.NumGoroutine()
 
-	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
+	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
 		t.Fatal(err)
 	}
 
@@ -210,8 +211,8 @@ func TestSSHConsoleNodeLifecycle(t *testing.T) {
 	t.Logf("goroutines with node: %d (added %d)", runtime.NumGoroutine(), runtime.NumGoroutine()-goroutinesBefore)
 
 	// Remove the node. The manager is the sole authority on node lifetime, so
-	// cancelling through UpdateNodes must be enough to stop Run.
-	if err := manager.UpdateNodes(ctx, map[string]*nodes.NodeConsoleInfo{}, map[string]compcredentials.CompCredentials{}); err != nil {
+	// cancelling through UpdateNodesAndCredentials must be enough to stop Run.
+	if err := manager.UpdateNodesAndCredentials(ctx, map[string]*nodes.NodeConsoleInfo{}, map[string]compcredentials.CompCredentials{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -254,7 +255,7 @@ func TestSlowClientGetsDropNotice(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
+	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/ssh/scale_test.go
+++ b/internal/ssh/scale_test.go
@@ -79,8 +79,8 @@ func TestSSHConsoleManagerScale(t *testing.T) {
 
 	goroutinesBefore := runtime.NumGoroutine()
 
-	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
-		t.Fatalf("UpdateNodes: %v", err)
+	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
+		t.Fatalf("UpdateNodesAndCredentials: %v", err)
 	}
 
 	// Wait until all nodes have established a shell session on the server.

--- a/internal/ssh/server_test.go
+++ b/internal/ssh/server_test.go
@@ -261,7 +261,9 @@ func newManager(t *testing.T, logsDir string) *ssh.SSHConsoleManager {
 	cfg.TCPKeepAlive = 0
 	cfg.ReconnectMinInterval = 250 * time.Millisecond
 	cfg.ReconnectMaxInterval = 1 * time.Second
-	return ssh.NewSSHConsoleManager(cfg, "", logsDir)
+	manager := ssh.NewSSHConsoleManager(cfg, "", logsDir)
+	t.Cleanup(manager.Wait)
+	return manager
 }
 
 // waitForMarker reads from ch until the accumulated output contains marker or


### PR DESCRIPTION
Update SSH membership even when credentials cannot be fetched, while
preserving credentials on existing consoles. Successful credential reads
remain authoritative and can reconnect only the affected nodes.

Signed-off-by: Chris Harris <cjh@lbl.gov>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>