### PR TITLE
refactor(creds): maintain a complete credential snapshot

### DIFF
--- a/cmd/remote-console/service.go
+++ b/cmd/remote-console/service.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -37,9 +36,14 @@ type ConmanService interface {
 	SignalConmanHUP() error
 }
 
-// CredsService defines the interface for credentials service operations
+// CredsService defines the interface for credentials service operations.
+//
+// CheckForUpdates is what refreshes the service's view of the credential store;
+// GetPasswords serves that view without going near the store. Callers therefore
+// see credentials as of the last refresh, and only watchForCredUpdates calls
+// CheckForUpdates — see the note there for why that has to stay true.
 type CredsService interface {
-	GetPasswordsWithRetries(ctx context.Context, bmcXNames []string, maxTries, waitSecs int) (map[string]compcreds.CompCredentials, error)
+	GetPasswords(xnames []string) map[string]compcreds.CompCredentials
 	EnsureConsoleKeysPresent() (bool, error)
 	CheckForUpdates() (bool, error)
 }
@@ -58,7 +62,6 @@ type LogsService interface {
 type SSHConsoleService interface {
 	UpdateNodes(ctx context.Context, sshNodes map[string]*nodes.NodeConsoleInfo) error
 	UpdateCredentials(passwords map[string]compcreds.CompCredentials)
-	NodesAwaitingCredentials() []string
 	ReopenLogs()
 }
 
@@ -96,8 +99,8 @@ func filterXNames(sshNodes map[string]*nodes.NodeConsoleInfo) []string {
 // Watch for node updates and signal conman and log rotation as needed.
 //
 // This loop decides membership only. Credentials belong to watchForCredUpdates,
-// which picks up any node registered here that is still waiting for its Vault
-// entry — see SSHConsoleService.NodesAwaitingCredentials.
+// which pushes the credential snapshot at the SSH manager on every tick and so
+// picks up whatever this loop registered.
 func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpClient *http.Client,
 	conmanService ConmanService, logsService LogsService,
 	sshService SSHConsoleService) {
@@ -150,11 +153,14 @@ func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpC
 
 // Watch for credential updates and signal conman and SSH manager as needed.
 //
-// This loop is the sole owner of credential delivery to the SSH manager. It has
-// two reasons to fetch: Vault changed, or a node registered by
-// watchForNodesUpdates has not received its entry yet. The second is what feeds
-// a node that joined the cluster after startup — nothing in Vault changed for
-// it, so change detection alone would leave it parked forever.
+// This loop is the only caller of CheckForUpdates, and that is a constraint
+// rather than a coincidence: CheckForUpdates reports what has changed since the
+// last call, so a second caller would consume changes this one needs to see and
+// conman would never be told to pick them up.
+//
+// It is also the sole owner of credential delivery to the SSH manager. Delivery
+// does not wait for a reported change — a node that registered after the last
+// tick needs its entry even though nothing in the store changed for it.
 func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig,
 	credsService CredsService, conmanService ConmanService, sshService SSHConsoleService) {
 	ticker := time.NewTicker(time.Duration(config.CredsMonitorInterval) * time.Second)
@@ -168,38 +174,21 @@ func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig,
 		case <-ticker.C:
 			changed, err := credsService.CheckForUpdates()
 			if err != nil {
+				// The refresh failed, so the previous snapshot still stands.
+				// Pushing it below is still worth doing: a node that registered
+				// since the last tick can be fed from what is already known
+				// rather than waiting for the store to come back.
 				slog.Error("Failed to check for credential updates", "error", err)
 			}
 
-			awaiting := sshService.NodesAwaitingCredentials()
-			if len(awaiting) > 0 {
-				slog.Info("SSH console nodes awaiting credentials", "count", len(awaiting))
-			}
-
-			if changed || len(awaiting) > 0 {
-				// Only the SSH manager needs the passwords here. conman picks
-				// the new ones up when runConman rebuilds conman.conf after the
-				// SIGTERM below.
-				sshNodes := filterSSHNodes(nodes.CurrentNodes())
-				if len(sshNodes) > 0 {
-					// Retry inside the call only when Vault reported a change,
-					// which means the entries are there to be read. When merely
-					// chasing nodes that are waiting, this ticker is the retry —
-					// an entry that has not been provisioned yet would otherwise
-					// burn the retry budget on every tick to learn the same thing.
-					tries, wait := 1, 0
-					if changed {
-						tries, wait = 3, 5
-					}
-					passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(sshNodes), tries, wait)
-					if err != nil {
-						// Whatever came back is still worth applying: absent node
-						// IDs are left alone, so a partial map can only move nodes
-						// forward onto credentials that did arrive.
-						slog.Error("Failed to fetch updated credentials", "error", err)
-					}
-					sshService.UpdateCredentials(passwords)
-				}
+			// Hand the refreshed snapshot to the SSH manager on every tick. It
+			// applies only what actually differs, so this costs a map walk and
+			// covers both reasons a node might need feeding: its entry changed,
+			// or it registered after the last tick and has never had one. Only
+			// the SSH manager needs the passwords here — conman picks the new
+			// ones up when runConman rebuilds conman.conf after the SIGTERM below.
+			if sshNodes := filterSSHNodes(nodes.CurrentNodes()); len(sshNodes) > 0 {
+				sshService.UpdateCredentials(credsService.GetPasswords(filterXNames(sshNodes)))
 			}
 
 			// Restart conman only for a real credential change. A node waiting on
@@ -286,16 +275,16 @@ func runConman(ctx context.Context, conmanService ConmanService, credService Cre
 		currentNodes := nodes.CurrentNodes()
 		ipmiNodes := filterIPMINodes(currentNodes)
 
+		// Whatever the snapshot holds right now. A node it does not cover is
+		// configured without credentials rather than waited for: conmand has
+		// already been stopped to get here, so waiting would keep every other
+		// console down for the sake of one, and this loop cannot make the
+		// credentials arrive any sooner — only watchForCredUpdates can. When
+		// they do arrive it reports them as a change, which brings us back
+		// through here.
 		var passwords map[string]compcreds.CompCredentials
-		var err error
 		if len(ipmiNodes) > 0 {
-			passwords, err = credService.GetPasswordsWithRetries(ctx, filterXNames(ipmiNodes), 15, 10)
-			if err != nil {
-				slog.Warn("Credential retrieval ended early", "error", err)
-				if errors.Is(err, context.Canceled) {
-					return
-				}
-			}
+			passwords = credService.GetPasswords(filterXNames(ipmiNodes))
 		}
 
 		hasNodes, err := conmanService.ConfigureConman(ipmiNodes, passwords)

--- a/internal/creds/creds.go
+++ b/internal/creds/creds.go
@@ -9,20 +9,26 @@ package creds
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"fmt"
 	"log/slog"
 	"os"
-	"time"
+	"sync"
 
 	compcreds "github.com/Cray-HPE/hms-compcredentials"
 	sstorage "github.com/Cray-HPE/hms-securestorage"
 )
 
 type CredsService struct {
-	config                 CredsConfig
-	previousPasswords      map[string]compcreds.CompCredentials
+	config CredsConfig
+
+	// passwordsMu guards passwords.
+	passwordsMu sync.RWMutex
+
+	// passwords is the credential snapshot from the last inventory refresh.
+	// checkIfPasswordsChanged is its only writer.
+	passwords map[string]compcreds.CompCredentials
+
 	previousPrivateKeyHash []byte
 	previousCertHash       []byte
 }
@@ -30,7 +36,7 @@ type CredsService struct {
 func NewCredsService(config CredsConfig) *CredsService {
 	return &CredsService{
 		config:                 config,
-		previousPasswords:      nil,
+		passwords:              nil,
 		previousPrivateKeyHash: nil,
 		previousCertHash:       nil,
 	}
@@ -96,54 +102,19 @@ func getPasswords(config CredsConfig, bmcXNames []string) (map[string]compcreds.
 	return ccreds, nil
 }
 
-// Look up the creds for the input endpoints with retries
-func (cs *CredsService) GetPasswordsWithRetries(ctx context.Context, bmcXNames []string, maxTries, waitSecs int) (map[string]compcreds.CompCredentials, error) {
-	var passwords map[string]compcreds.CompCredentials = nil
-	var err error = nil
-	for numTries := 0; numTries < maxTries; numTries++ {
-		select {
-		case <-ctx.Done():
-			slog.Info("Stopping credential retrieval due to context cancellation")
-			return passwords, ctx.Err()
-		default:
-		}
+// GetPasswords returns credentials from the last refresh for the given xnames.
+// Missing credentials are omitted. CheckForUpdates refreshes the snapshot.
+func (cs *CredsService) GetPasswords(xnames []string) map[string]compcreds.CompCredentials {
+	cs.passwordsMu.RLock()
+	defer cs.passwordsMu.RUnlock()
 
-		slog.Debug("Get passwords with retry", "attempt", numTries)
-		passwords, err = getPasswords(cs.config, bmcXNames)
-
-		slog.Debug("Passwords retrieved", "count", len(passwords))
-
-		if err != nil {
-			slog.Error("Error retrieving passwords", "error", err)
-		}
-
-		foundAll := true
-		for _, nn := range bmcXNames {
-			_, ok := passwords[nn]
-			if !ok {
-				slog.Warn("Missing credentials for", "xname", nn)
-				foundAll = false
-			}
-		}
-		if foundAll {
-			slog.Info("Retrieved all passwords")
-			break
-		}
-		slog.Warn("Only retrieved subset of creds from vault, waiting and trying again",
-			"attempt", numTries, "retrieved", len(passwords), "total", len(bmcXNames))
-
-		select {
-		case <-ctx.Done():
-			slog.Info("Stopping credential retrieval due to context cancellation")
-			return passwords, ctx.Err()
-		case <-time.After(time.Duration(waitSecs) * time.Second):
+	passwords := make(map[string]compcreds.CompCredentials, len(xnames))
+	for _, xname := range xnames {
+		if creds, ok := cs.passwords[xname]; ok {
+			passwords[xname] = creds
 		}
 	}
-	slog.Warn("Maximum password attempts reached, configuring conman with what we have")
-
-	cs.previousPasswords = passwords
-
-	return passwords, err
+	return passwords
 }
 
 func hashString(s string) ([]byte, error) {

--- a/internal/creds/monitor.go
+++ b/internal/creds/monitor.go
@@ -41,31 +41,77 @@ func (cs *CredsService) CheckForUpdates() (bool, error) {
 	return (len(ids) > 0 && passwordsChanged) || keysChanged, nil
 }
 
+// checkIfPasswordsChanged refreshes the service's snapshot of the credential
+// store and reports whether any of the given nodes' credentials differ from what
+// the previous refresh saw.
+//
+// Refreshing and comparing are one operation on purpose. This is the only place
+// that reads the whole node set, so the snapshot it leaves behind always covers
+// exactly what the next call will compare — and everything GetPasswords is asked
+// for. Were a caller fetching some subset to record its result instead, the nodes
+// it left out would go missing from the snapshot and read as changed forever
+// after, which is precisely the failure this replaced.
 func (cs *CredsService) checkIfPasswordsChanged(xnames []string) (bool, error) {
-	if cs.previousPasswords == nil {
+	if len(xnames) == 0 {
+		// Nothing to compare, and nothing worth recording: an empty snapshot
+		// would make every node look new once inventory arrives.
 		return false, nil
 	}
-	currentPasswords, err := getPasswords(cs.config, xnames)
 
+	currentPasswords, err := getPasswords(cs.config, xnames)
 	if err != nil {
+		// Leave the snapshot alone. A failed fetch says nothing about what is in
+		// the store, so overwriting it would either hide a real change or invent
+		// one on the next call — and would strand every GetPasswords caller.
 		slog.Error("Error retrieving passwords while checking for credential changes", "error", err)
 		return false, err
 	}
+
+	cs.passwordsMu.Lock()
+	defer cs.passwordsMu.Unlock()
+
+	if cs.passwords == nil {
+		// First observation: everything read here is news. Reporting nothing
+		// would be a hole rather than an economy — conman is rebuilt only when
+		// this reports a change, and it starts before this snapshot exists, so
+		// staying quiet leaves it running on the credentials it did not have.
+		//
+		// An empty first read is not news, and claiming otherwise would restart
+		// conman for nothing. Recording it is still right: an entry provisioned
+		// later is then reported by the loop below.
+		cs.passwords = currentPasswords
+		return len(currentPasswords) > 0, nil
+	}
+
+	changed := false
 	for _, xname := range xnames {
 		currentCreds, ok := currentPasswords[xname]
 		if !ok {
 			slog.Warn("Missing credentials detected while checking for credential changes", "xname", xname)
 			continue
 		}
-		previousCreds := cs.previousPasswords[xname]
+
+		previousCreds, seen := cs.passwords[xname]
+		if !seen {
+			// An entry that has just been provisioned. Absent is not the same as
+			// empty: comparing against the zero value here would report every
+			// unobserved node as a password change.
+			slog.Info("New credentials detected. Conman will be reconfigured.", "xname", xname)
+			changed = true
+			break
+		}
 
 		if (currentCreds.Username != previousCreds.Username) || (currentCreds.Password != previousCreds.Password) {
 			slog.Info("Change detected in the passwords. Conman will be reconfigured.")
-			return true, nil
+			changed = true
+			break
 		}
 	}
 
-	return false, nil
+	// Replace rather than merge, so entries for departed nodes fall away.
+	cs.passwords = currentPasswords
+
+	return changed, nil
 }
 
 func (cs *CredsService) checkIfKeysChanged() (bool, error) {

--- a/internal/creds/monitor_test.go
+++ b/internal/creds/monitor_test.go
@@ -5,7 +5,6 @@
 package creds
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -15,31 +14,33 @@ import (
 	"github.com/Cray-HPE/hms-securestorage"
 )
 
-func TestCheckIfPasswordsChanged(t *testing.T) {
-	tempDir := t.TempDir()
+// storeCred writes a credential entry for one xname, as the credential store
+// would hold it.
+func storeCred(t *testing.T, ss securestorage.SecureStorage, xname, password string) {
+	t.Helper()
+	value := map[string]string{
+		"Username": "admin",
+		"Password": password,
+		"Xname":    xname,
+		"URL":      "https://" + xname + "/redfish/v1/Managers/BMC",
+	}
+	require.NoError(t, ss.Store(fmt.Sprintf("hms-creds/%s", xname), value))
+}
 
-	// Setup a local secure storage file
-	localStoreFilePath := filepath.Join(tempDir, "secure_store")
+// newTestCredsService returns a CredsService backed by a local secret store
+// holding one entry per xname in passwords, along with the store so the test can
+// change entries afterwards.
+func newTestCredsService(t *testing.T, passwords map[string]string) (*CredsService, securestorage.SecureStorage) {
+	t.Helper()
+
+	localStoreFilePath := filepath.Join(t.TempDir(), "secure_store")
 	localStoreKey, err := securestorage.GenerateMasterKey()
 	require.NoError(t, err)
 	ss, err := securestorage.NewLocalSecretStore(localStoreKey, localStoreFilePath, true)
 	require.NoError(t, err)
 
-	testPasswords := map[string]string{
-		"x0c0s1b0": "password1",
-		"x0c0s1b1": "password2",
-	}
-	nodes := []string{"x0c0s1b0", "x0c0s1b1"}
-
-	for node, password := range testPasswords {
-		value := map[string]string{
-			"Username": "admin",
-			"Password": password,
-			"Xname":    node,
-			"URL":      "https://" + node + "/redfish/v1/Managers/BMC",
-		}
-		err = ss.Store(fmt.Sprintf("hms-creds/%s", node), value)
-		require.NoError(t, err)
+	for xname, password := range passwords {
+		storeCred(t, ss, xname, password)
 	}
 
 	config := DefaultCredsConfig()
@@ -47,35 +48,151 @@ func TestCheckIfPasswordsChanged(t *testing.T) {
 	config.LocalStoreFilePath = localStoreFilePath
 	config.LocalStoreKey = localStoreKey
 
-	service := NewCredsService(config)
+	return NewCredsService(config), ss
+}
 
-	changed, err := service.checkIfPasswordsChanged(nodes)
-	if err != nil {
-		t.Fatalf("Error checking if passwords changed: %v", err)
-	}
+func TestCheckIfPasswordsChanged(t *testing.T) {
+	xnames := []string{"x0c0s1b0", "x0c0s1b1"}
+	service, ss := newTestCredsService(t, map[string]string{
+		"x0c0s1b0": "password1",
+		"x0c0s1b1": "password2",
+	})
 
-	require.False(t, changed, "Passwords should not have changed")
-
-	// Call GetPasswordsWithRetry to set previousPasswords
-	_, err = service.GetPasswordsWithRetries(context.Background(), nodes, 3, 1)
+	changed, err := service.checkIfPasswordsChanged(xnames)
 	require.NoError(t, err)
+	require.True(t, changed, "the first check learns every credential, so it reports a change")
 
-	// Now change a password
-	value := map[string]string{
-		"Username": "admin",
-		"Password": "newpassword",
-		"Xname":    "x0c0s1b0",
-		"URL":      "https://x0c0s1b0/redfish/v1/Managers/BMC",
-	}
-	err = ss.Store("hms-creds/x0c0s1b0", value)
+	changed, err = service.checkIfPasswordsChanged(xnames)
 	require.NoError(t, err)
+	require.False(t, changed, "unchanged passwords should not report a change")
 
-	changed, err = service.checkIfPasswordsChanged(nodes)
-	if err != nil {
-		t.Fatalf("Error checking if passwords changed: %v", err)
-	}
+	storeCred(t, ss, "x0c0s1b0", "newpassword")
 
-	require.True(t, changed, "Passwords should have changed")
+	changed, err = service.checkIfPasswordsChanged(xnames)
+	require.NoError(t, err)
+	require.True(t, changed, "a changed password should report a change")
+}
+
+// GetPasswords answers from the snapshot the check records, and reading it does
+// not disturb the snapshot. That is what keeps subset reads honest: runConman
+// asks about the IPMI nodes and the credential watcher about the SSH ones, and
+// while each of those was a fetch that recorded the baseline, each erased the
+// other's half and every tick afterwards reported a change.
+func TestGetPasswordsServesTheRecordedSnapshot(t *testing.T) {
+	ipmiNode, sshNode := "x0c0s1b0", "x0c0s2b0"
+	all := []string{ipmiNode, sshNode}
+
+	service, ss := newTestCredsService(t, map[string]string{
+		ipmiNode: "password1",
+		sshNode:  "password2",
+	})
+
+	require.Empty(t, service.GetPasswords(all), "nothing is known before the first check")
+
+	changed, err := service.checkIfPasswordsChanged(all)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	ipmiOnly := service.GetPasswords([]string{ipmiNode})
+	require.Len(t, ipmiOnly, 1)
+	require.Equal(t, "password1", ipmiOnly[ipmiNode].Password)
+	require.Empty(t, service.GetPasswords([]string{"x0c0s9b0"}), "an unknown node is absent, not empty")
+
+	changed, err = service.checkIfPasswordsChanged(all)
+	require.NoError(t, err)
+	require.False(t, changed, "reading one node's entry is not a change to another's")
+
+	storeCred(t, ss, sshNode, "newpassword")
+	require.Equal(t, "password2", service.GetPasswords(all)[sshNode].Password,
+		"the snapshot is what the last check read, not what the store holds now")
+
+	changed, err = service.checkIfPasswordsChanged(all)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "newpassword", service.GetPasswords(all)[sshNode].Password,
+		"a check that reports a change should leave the new credentials behind")
+}
+
+// A first observation that found nothing is not news, and must not restart
+// conman for it. Recording the empty read is still right: the entry arriving
+// afterwards is what the change is.
+func TestFirstObservationWithNoEntriesIsNotAChange(t *testing.T) {
+	xnames := []string{"x0c0s1b0"}
+	// Another node's entry, so the store exists but holds nothing for xnames.
+	service, ss := newTestCredsService(t, map[string]string{"x0c0s9b0": "unrelated"})
+
+	changed, err := service.checkIfPasswordsChanged(xnames)
+	require.NoError(t, err)
+	require.False(t, changed, "a first read that found no entries is not a change")
+	require.NotNil(t, service.passwords, "the empty read should still be recorded")
+
+	storeCred(t, ss, "x0c0s1b0", "password1")
+
+	changed, err = service.checkIfPasswordsChanged(xnames)
+	require.NoError(t, err)
+	require.True(t, changed, "the entry arriving afterwards is the change")
+}
+
+// A failed fetch must leave the baseline alone. Recording its empty result would
+// switch detection off until some later fetch happened to succeed.
+func TestFailedCheckLeavesBaselineIntact(t *testing.T) {
+	xnames := []string{"x0c0s1b0"}
+	service, ss := newTestCredsService(t, map[string]string{"x0c0s1b0": "password1"})
+
+	changed, err := service.checkIfPasswordsChanged(xnames)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	workingAdapter := service.config.SecureStorageAdapter
+	service.config.SecureStorageAdapter = StorageAdapter("bogus")
+	changed, err = service.checkIfPasswordsChanged(xnames)
+	require.Error(t, err)
+	require.False(t, changed)
+	service.config.SecureStorageAdapter = workingAdapter
+
+	changed, err = service.checkIfPasswordsChanged(xnames)
+	require.NoError(t, err)
+	require.False(t, changed, "recovering from a failed fetch is not a credential change")
+
+	storeCred(t, ss, "x0c0s1b0", "newpassword")
+
+	changed, err = service.checkIfPasswordsChanged(xnames)
+	require.NoError(t, err)
+	require.True(t, changed, "detection should still work after a failed fetch")
+}
+
+// An entry appearing after the baseline was recorded is a real change: the node
+// was already in inventory but had no credentials yet.
+func TestNewlyProvisionedCredentialIsAChange(t *testing.T) {
+	existing, provisioned := "x0c0s1b0", "x0c0s1b1"
+	xnames := []string{existing, provisioned}
+
+	service, ss := newTestCredsService(t, map[string]string{existing: "password1"})
+
+	changed, err := service.checkIfPasswordsChanged(xnames)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	storeCred(t, ss, provisioned, "password2")
+
+	changed, err = service.checkIfPasswordsChanged(xnames)
+	require.NoError(t, err)
+	require.True(t, changed, "a newly provisioned entry should report a change")
+}
+
+// Before inventory arrives there is nothing worth recording. Seeding an empty
+// baseline would make every node read as newly provisioned on the next tick.
+func TestCheckWithNoNodesDoesNotRecordBaseline(t *testing.T) {
+	service, _ := newTestCredsService(t, map[string]string{"x0c0s1b0": "password1"})
+
+	changed, err := service.checkIfPasswordsChanged(nil)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Nil(t, service.passwords, "an empty check should not record a snapshot")
+
+	changed, err = service.checkIfPasswordsChanged([]string{"x0c0s1b0"})
+	require.NoError(t, err)
+	require.True(t, changed, "the empty check should not have counted as the first observation")
 }
 
 func TestCheckIfKeysChanged(t *testing.T) {

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -91,8 +91,7 @@ func credsChanged(a, b compcredentials.CompCredentials) bool {
 // succeed — or to have happened at all.
 //
 // A node discovered here starts with no credentials. It registers and accepts
-// Attach, but does not connect until UpdateCredentials brings it a Vault entry;
-// see NodesAwaitingCredentials.
+// Attach, but does not connect until UpdateCredentials brings it a Vault entry.
 func (m *SSHConsoleManager) UpdateNodes(
 	ctx context.Context,
 	sshNodes map[string]*nodes.NodeConsoleInfo,
@@ -185,25 +184,6 @@ func (m *SSHConsoleManager) UpdateCredentials(passwords map[string]compcredentia
 	for _, u := range updates {
 		u.console.UpdateCreds(u.creds)
 	}
-}
-
-// NodesAwaitingCredentials returns the IDs of managed nodes that have not yet
-// received a Vault entry. Those nodes are registered but parked — they will not
-// connect until UpdateCredentials reaches them.
-//
-// The credential watcher uses this to decide it has work to do. Watching Vault
-// for changes is not enough on its own: a node added after startup needs its
-// entry fetched even though nothing in Vault changed.
-func (m *SSHConsoleManager) NodesAwaitingCredentials() []string {
-	m.consolesMu.RLock()
-	defer m.consolesMu.RUnlock()
-	var waiting []string
-	for nodeID, console := range m.consoles {
-		if console.currentCreds() == nil {
-			waiting = append(waiting, nodeID)
-		}
-	}
-	return waiting
 }
 
 // ReopenLogs signals all active consoles to reopen their log files after rotation.

--- a/internal/ssh/manager_test.go
+++ b/internal/ssh/manager_test.go
@@ -170,10 +170,10 @@ func TestUpdateNodesAddsAndRemovesNodes(t *testing.T) {
 }
 
 // TestUpdateCredentialsIgnoresAbsentNodes pins the property that lets callers
-// pass a credential map they cannot vouch for. GetPasswordsWithRetries returns
-// whatever it managed to fetch with a nil error once it exhausts its retries,
-// so an absent nodeID says nothing about the node — only that this fetch did
-// not bring it back. UpdateCredentials must therefore leave absent nodes alone:
+// pass a credential map they cannot vouch for. GetPasswords answers from a
+// snapshot that is only as complete as the last refresh, so an absent nodeID
+// says nothing about the node — only that the refresh did not bring it back.
+// UpdateCredentials must therefore leave absent nodes alone:
 // treating absence as a change would tear down a working console every time the
 // credential store had a bad minute.
 func TestUpdateCredentialsIgnoresAbsentNodes(t *testing.T) {
@@ -283,44 +283,5 @@ func TestNodeWithoutCredentialsWaitsInsteadOfDialling(t *testing.T) {
 	case <-sessionCh:
 	case <-time.After(15 * time.Second):
 		t.Fatal("node did not connect after its credentials arrived")
-	}
-}
-
-// TestNodesAwaitingCredentials covers the signal the credential watcher runs
-// on. A node added after startup needs its Vault entry fetched even though
-// nothing in Vault changed, so change detection alone would leave it parked;
-// the watcher asks the manager who is still waiting instead.
-func TestNodesAwaitingCredentials(t *testing.T) {
-	id, nodeMap, passwords := singleNode(t, deadAddr(t))
-
-	manager := newManager(t, t.TempDir())
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	if got := manager.NodesAwaitingCredentials(); len(got) != 0 {
-		t.Fatalf("NodesAwaitingCredentials on an empty manager = %v, want none", got)
-	}
-
-	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
-		t.Fatal(err)
-	}
-	got := manager.NodesAwaitingCredentials()
-	if len(got) != 1 || got[0] != id {
-		t.Fatalf("NodesAwaitingCredentials after adding %s = %v, want [%s]", id, got, id)
-	}
-
-	// UpdateCredentials applies synchronously, so the node has stopped waiting
-	// by the time it returns — no polling window here.
-	manager.UpdateCredentials(passwords)
-	if got := manager.NodesAwaitingCredentials(); len(got) != 0 {
-		t.Fatalf("NodesAwaitingCredentials after delivery = %v, want none", got)
-	}
-
-	// A node dropped from inventory is not waiting for anything.
-	if err := manager.UpdateNodes(ctx, map[string]*nodes.NodeConsoleInfo{}); err != nil {
-		t.Fatal(err)
-	}
-	if got := manager.NodesAwaitingCredentials(); len(got) != 0 {
-		t.Fatalf("NodesAwaitingCredentials after removing the node = %v, want none", got)
 	}
 }


### PR DESCRIPTION
Let change detection own the store baseline and refresh one
inventory-wide snapshot. Callers read subsets from that snapshot without
narrowing or replacing the service view.

Signed-off-by: Chris Harris <cjh@lbl.gov>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>