### PR TITLE
fix(service): preserve complete inventory and credential views

### DIFF
--- a/cmd/remote-console/service.go
+++ b/cmd/remote-console/service.go
@@ -60,20 +60,9 @@ type LogsService interface {
 // the concrete *ssh.SSHConsoleManager is passed to console.SetupRoutes, which
 // uses it directly.
 type SSHConsoleService interface {
-	UpdateNodes(ctx context.Context, sshNodes map[string]*nodes.NodeConsoleInfo) error
+	UpdateNodes(ctx context.Context, nodes map[string]*nodes.NodeConsoleInfo) error
 	UpdateCredentials(passwords map[string]compcreds.CompCredentials)
 	ReopenLogs()
-}
-
-// filterSSHNodes returns the subset of nodes with SSH connection type.
-func filterSSHNodes(allNodes map[string]*nodes.NodeConsoleInfo) map[string]*nodes.NodeConsoleInfo {
-	result := make(map[string]*nodes.NodeConsoleInfo)
-	for id, n := range allNodes {
-		if n.IsSSH() {
-			result[id] = n
-		}
-	}
-	return result
 }
 
 // filterIPMINodes returns the subset of nodes with IPMI connection type.
@@ -88,9 +77,9 @@ func filterIPMINodes(allNodes map[string]*nodes.NodeConsoleInfo) map[string]*nod
 }
 
 // filterXNames returns the xnames from a node map.
-func filterXNames(sshNodes map[string]*nodes.NodeConsoleInfo) []string {
-	xnames := make([]string, 0, len(sshNodes))
-	for id := range sshNodes {
+func filterXNames(nodes map[string]*nodes.NodeConsoleInfo) []string {
+	xnames := make([]string, 0, len(nodes))
+	for id := range nodes {
 		xnames = append(xnames, id)
 	}
 	return xnames
@@ -123,21 +112,15 @@ func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpC
 
 				currentNodes := nodes.CurrentNodes()
 
-				// Membership first: this is the only thing a node change is
-				// actually reporting, and it needs no credentials to apply.
-				sshNodes := filterSSHNodes(currentNodes)
-				if err := sshService.UpdateNodes(ctx, sshNodes); err != nil {
+				if err := sshService.UpdateNodes(ctx, currentNodes); err != nil {
 					slog.Error("Failed to update SSH console nodes", "error", err)
 				}
 
-				// conman needs no help here. runConman regenerates conman.conf
-				// from the current node set and a fresh credential fetch every
-				// time conmand exits, so signalling it is the whole job.
 				if err := conmanService.SignalConmanTERM(); err != nil {
 					slog.Error("Failed to signal conman with SIGTERM", "error", err)
 				}
 
-				// Update log rotation configuration.
+				// also update log rotation configuration
 				slog.Info("Updating log rotation configuration for node changes")
 				if err := logsService.UpdateLogRotateConf(consoleLogsPath, currentNodes); err != nil {
 					slog.Error("Failed to update log rotation configuration for node changes", "error", err)
@@ -175,26 +158,14 @@ func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig,
 			changed, err := credsService.CheckForUpdates()
 			if err != nil {
 				// The refresh failed, so the previous snapshot still stands.
-				// Pushing it below is still worth doing: a node that registered
-				// since the last tick can be fed from what is already known
-				// rather than waiting for the store to come back.
 				slog.Error("Failed to check for credential updates", "error", err)
 			}
 
-			// Hand the refreshed snapshot to the SSH manager on every tick. It
-			// applies only what actually differs, so this costs a map walk and
-			// covers both reasons a node might need feeding: its entry changed,
-			// or it registered after the last tick and has never had one. Only
-			// the SSH manager needs the passwords here — conman picks the new
-			// ones up when runConman rebuilds conman.conf after the SIGTERM below.
-			if sshNodes := filterSSHNodes(nodes.CurrentNodes()); len(sshNodes) > 0 {
-				sshService.UpdateCredentials(credsService.GetPasswords(filterXNames(sshNodes)))
-			}
+			names := filterXNames(nodes.CurrentNodes())
+			sshService.UpdateCredentials(credsService.GetPasswords(names))
 
-			// Restart conman only for a real credential change. A node waiting on
-			// its first Vault entry is no reason to drop every IPMI console.
 			if changed {
-				slog.Info("Credential changes detected, restarting conman")
+				slog.Info("Credential changes detected, signaling conman to restart")
 				if err := conmanService.SignalConmanTERM(); err != nil {
 					slog.Error("Failed to signal conman with SIGTERM", "error", err)
 				}
@@ -275,13 +246,6 @@ func runConman(ctx context.Context, conmanService ConmanService, credService Cre
 		currentNodes := nodes.CurrentNodes()
 		ipmiNodes := filterIPMINodes(currentNodes)
 
-		// Whatever the snapshot holds right now. A node it does not cover is
-		// configured without credentials rather than waited for: conmand has
-		// already been stopped to get here, so waiting would keep every other
-		// console down for the sake of one, and this loop cannot make the
-		// credentials arrive any sooner — only watchForCredUpdates can. When
-		// they do arrive it reports them as a change, which brings us back
-		// through here.
 		var passwords map[string]compcreds.CompCredentials
 		if len(ipmiNodes) > 0 {
 			passwords = credService.GetPasswords(filterXNames(ipmiNodes))
@@ -421,6 +385,7 @@ func runService(config remoteConsoleConfig) error {
 			// This is a fatal error - don't start with unprotected endpoints
 			slog.Error("Failed to initialize JWT authentication after all retries - refusing to start with unprotected endpoints")
 			serviceStopCtx()
+			sshManager.Shutdown()
 			return fmt.Errorf("failed to fetch JWKS from %s: %w", config.JwksURL, lastErr)
 		}
 	} else {
@@ -454,11 +419,9 @@ func runService(config remoteConsoleConfig) error {
 		sig := <-sigs
 		slog.Info("Detected signal to close service", "signal", sig)
 
-		// Cancel service context to stop background goroutines
-		serviceStopCtx()
-
 		// Shutdown signal with grace period of 30 seconds
 		shutdownCtx, shutdownCtxCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer shutdownCtxCancel()
 
 		go func() {
 			<-shutdownCtx.Done()
@@ -468,6 +431,10 @@ func runService(config remoteConsoleConfig) error {
 				os.Exit(1)
 			}
 		}()
+
+		// Stop background goroutines and wait for SSH console cleanup
+		serviceStopCtx()
+		sshManager.Shutdown()
 
 		// Trigger graceful shutdown
 		err := server.Shutdown(shutdownCtx)

--- a/internal/creds/monitor.go
+++ b/internal/creds/monitor.go
@@ -10,6 +10,7 @@ package creds
 import (
 	"log/slog"
 
+	compcreds "github.com/Cray-HPE/hms-compcredentials"
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
 )
 
@@ -41,28 +42,16 @@ func (cs *CredsService) CheckForUpdates() (bool, error) {
 	return (len(ids) > 0 && passwordsChanged) || keysChanged, nil
 }
 
-// checkIfPasswordsChanged refreshes the service's snapshot of the credential
-// store and reports whether any of the given nodes' credentials differ from what
-// the previous refresh saw.
-//
-// Refreshing and comparing are one operation on purpose. This is the only place
-// that reads the whole node set, so the snapshot it leaves behind always covers
-// exactly what the next call will compare — and everything GetPasswords is asked
-// for. Were a caller fetching some subset to record its result instead, the nodes
-// it left out would go missing from the snapshot and read as changed forever
-// after, which is precisely the failure this replaced.
+// checkIfPasswordsChanged refreshes the credential snapshot and reports changes.
 func (cs *CredsService) checkIfPasswordsChanged(xnames []string) (bool, error) {
 	if len(xnames) == 0 {
-		// Nothing to compare, and nothing worth recording: an empty snapshot
-		// would make every node look new once inventory arrives.
+		// Preserve the snapshot until inventory is available.
 		return false, nil
 	}
 
 	currentPasswords, err := getPasswords(cs.config, xnames)
 	if err != nil {
-		// Leave the snapshot alone. A failed fetch says nothing about what is in
-		// the store, so overwriting it would either hide a real change or invent
-		// one on the next call — and would strand every GetPasswords caller.
+		// A failed read does not invalidate the previous snapshot.
 		slog.Error("Error retrieving passwords while checking for credential changes", "error", err)
 		return false, err
 	}
@@ -70,17 +59,22 @@ func (cs *CredsService) checkIfPasswordsChanged(xnames []string) (bool, error) {
 	cs.passwordsMu.Lock()
 	defer cs.passwordsMu.Unlock()
 
+	// Retain previous credentials when a read omits an inventoried node.
+	refreshed := make(map[string]compcreds.CompCredentials, len(xnames))
+	for _, xname := range xnames {
+		if creds, ok := currentPasswords[xname]; ok {
+			refreshed[xname] = creds
+			continue
+		}
+		if previous, seen := cs.passwords[xname]; seen {
+			refreshed[xname] = previous
+		}
+	}
+
 	if cs.passwords == nil {
-		// First observation: everything read here is news. Reporting nothing
-		// would be a hole rather than an economy — conman is rebuilt only when
-		// this reports a change, and it starts before this snapshot exists, so
-		// staying quiet leaves it running on the credentials it did not have.
-		//
-		// An empty first read is not news, and claiming otherwise would restart
-		// conman for nothing. Recording it is still right: an entry provisioned
-		// later is then reported by the loop below.
-		cs.passwords = currentPasswords
-		return len(currentPasswords) > 0, nil
+		// Report a non-empty first read so ConMan receives initial credentials.
+		cs.passwords = refreshed
+		return len(refreshed) > 0, nil
 	}
 
 	changed := false
@@ -93,9 +87,6 @@ func (cs *CredsService) checkIfPasswordsChanged(xnames []string) (bool, error) {
 
 		previousCreds, seen := cs.passwords[xname]
 		if !seen {
-			// An entry that has just been provisioned. Absent is not the same as
-			// empty: comparing against the zero value here would report every
-			// unobserved node as a password change.
 			slog.Info("New credentials detected. Conman will be reconfigured.", "xname", xname)
 			changed = true
 			break
@@ -108,8 +99,7 @@ func (cs *CredsService) checkIfPasswordsChanged(xnames []string) (bool, error) {
 		}
 	}
 
-	// Replace rather than merge, so entries for departed nodes fall away.
-	cs.passwords = currentPasswords
+	cs.passwords = refreshed
 
 	return changed, nil
 }

--- a/internal/creds/monitor_test.go
+++ b/internal/creds/monitor_test.go
@@ -73,11 +73,7 @@ func TestCheckIfPasswordsChanged(t *testing.T) {
 	require.True(t, changed, "a changed password should report a change")
 }
 
-// GetPasswords answers from the snapshot the check records, and reading it does
-// not disturb the snapshot. That is what keeps subset reads honest: runConman
-// asks about the IPMI nodes and the credential watcher about the SSH ones, and
-// while each of those was a fetch that recorded the baseline, each erased the
-// other's half and every tick afterwards reported a change.
+// GetPasswords serves subsets without changing the stored snapshot.
 func TestGetPasswordsServesTheRecordedSnapshot(t *testing.T) {
 	ipmiNode, sshNode := "x0c0s1b0", "x0c0s2b0"
 	all := []string{ipmiNode, sshNode}
@@ -178,6 +174,66 @@ func TestNewlyProvisionedCredentialIsAChange(t *testing.T) {
 	changed, err = service.checkIfPasswordsChanged(xnames)
 	require.NoError(t, err)
 	require.True(t, changed, "a newly provisioned entry should report a change")
+}
+
+// A short read is not evidence that an entry was deleted rather than merely
+// unavailable. Keep serving the last observation while the node remains in
+// inventory, but let inventory removal discard it.
+func TestMissingCredentialRetainsPreviousEntryUntilNodeLeavesInventory(t *testing.T) {
+	present, missing := "x0c0s1b0", "x0c0s1b1"
+	all := []string{present, missing}
+	service, ss := newTestCredsService(t, map[string]string{
+		present: "password1",
+		missing: "password2",
+	})
+
+	changed, err := service.checkIfPasswordsChanged(all)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	require.NoError(t, ss.Delete("hms-creds/"+missing))
+
+	changed, err = service.checkIfPasswordsChanged(all)
+	require.NoError(t, err)
+	require.False(t, changed, "an absent read is not a credential change")
+	require.Equal(t, "password2", service.GetPasswords(all)[missing].Password,
+		"the last-known credential should remain available")
+
+	changed, err = service.checkIfPasswordsChanged(all)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Contains(t, service.GetPasswords(all), missing,
+		"subsequent short reads should not poison the snapshot")
+
+	changed, err = service.checkIfPasswordsChanged([]string{present})
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.NotContains(t, service.GetPasswords(all), missing,
+		"a credential should fall away when its node leaves inventory")
+}
+
+// GetCompCreds keys its result by the xname inside each returned value. Some
+// adapters return a zero value for a missing key, producing an entry under "".
+// Rebuilding from inventory must neither retain that artifact nor report it as
+// a first observation.
+func TestFirstObservationIgnoresCredentialOutsideInventory(t *testing.T) {
+	xname := "x0c0s1b0"
+	service, ss := newTestCredsService(t, map[string]string{"x0c0s9b0": "unrelated"})
+	require.NoError(t, ss.Store("hms-creds/"+xname, map[string]string{
+		"Username": "admin",
+		"Password": "password1",
+	}))
+
+	changed, err := service.checkIfPasswordsChanged([]string{xname})
+	require.NoError(t, err)
+	require.False(t, changed, "an entry not keyed by an inventory xname is not news")
+	require.NotNil(t, service.passwords)
+	require.Empty(t, service.passwords)
+
+	storeCred(t, ss, xname, "password1")
+	changed, err = service.checkIfPasswordsChanged([]string{xname})
+	require.NoError(t, err)
+	require.True(t, changed, "a correctly keyed entry arriving later is a change")
 }
 
 // Before inventory arrives there is nothing worth recording. Seeding an empty

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -17,46 +17,33 @@ import (
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
 )
 
-// ErrNotConnected is returned by Write when the node exists but its SSH
-// session is currently down — during the initial connect, or between a drop
-// and the next retry. The input is discarded. It is deliberately distinct from
-// the "node not found" error: not-found is permanent and worth failing on,
-// whereas this clears on its own once the node reconnects.
+// ErrNotConnected means a managed node is temporarily disconnected. Write discards input and
+// returns this error until reconnect.
 var ErrNotConnected = errors.New("ssh console node not connected")
 
-// SSHConsoleManager manages the set of active SSHConsoles, one per SSH node in
-// the cluster inventory and keyed by node ID.
+// SSHConsoleManager manages one console for each SSH node.
 type SSHConsoleManager struct {
 	cfg      SSHConfig
 	keyPath  string
-	logsPath string // e.g. /var/log/conman/conman
+	logsPath string
 
-	// consolesMu protects the consoles map.
-	// Lock ordering: consolesMu → clientsMu, consolesMu → connMu
-	consolesMu sync.RWMutex
-	consoles   map[string]*SSHConsole
-	// cancels maps nodeID to the cancel func for that console's Run goroutine.
-	cancels map[string]context.CancelFunc
+	// consolesMu protects consoles.
+	consolesMu   sync.RWMutex
+	consoles     map[string]*SSHConsole
+	shuttingDown bool
 
-	// running tracks the live Run goroutines so callers can tell when the last
-	// one has released its log file. Cancelling a console's context only asks
-	// it to stop; the goroutine may still be opening or writing its log for a
-	// short while afterwards. See Wait.
+	// running tracks Run goroutines through final cleanup.
 	running sync.WaitGroup
 }
 
-// NewSSHConsoleManager creates a new manager. cfg should be built from
-// DefaultSSHConfig and checked with cfg.Validate; the manager does not correct
-// bad values. keyPath is the SSH private key path (may be empty if all nodes
-// use password auth). logsPath is the directory where per-node console log
-// files are written.
+// NewSSHConsoleManager creates a manager from validated configuration. keyPath may be empty when
+// all nodes use password authentication. logsPath stores per-node console logs.
 func NewSSHConsoleManager(cfg SSHConfig, keyPath, logsPath string) *SSHConsoleManager {
 	return &SSHConsoleManager{
 		cfg:      cfg,
 		keyPath:  keyPath,
 		logsPath: logsPath,
 		consoles: make(map[string]*SSHConsole),
-		cancels:  make(map[string]context.CancelFunc),
 	}
 }
 
@@ -77,52 +64,46 @@ func credsChanged(a, b compcredentials.CompCredentials) bool {
 	return a.Username != b.Username || a.Password != b.Password
 }
 
-// UpdateNodes diffs the provided SSH node map against the currently active set:
-// new nodes are started, removed nodes are cancelled, and nodes whose
-// connection parameters changed are restarted. Every node that survives the
-// diff keeps the credentials it is already using.
-//
-// ctx must be the long-lived service context — console goroutines run until it
-// is cancelled or the node leaves inventory.
-//
-// Membership is the only thing this decides; authentication belongs to
-// UpdateCredentials. A node change reports which nodes exist, and that says
-// nothing about credentials, so nothing here needs a credential fetch to
-// succeed — or to have happened at all.
-//
-// A node discovered here starts with no credentials. It registers and accepts
-// Attach, but does not connect until UpdateCredentials brings it a Vault entry.
+// UpdateNodes syncs managed consoles with the complete inventory. It starts new SSH nodes and
+// stops removed or retyped nodes. Connection changes restart a console with its existing
+// credentials, while new nodes wait for UpdateCredentials before connecting. ctx controls
+// console lifetime.
 func (m *SSHConsoleManager) UpdateNodes(
 	ctx context.Context,
-	sshNodes map[string]*nodes.NodeConsoleInfo,
+	nodes map[string]*nodes.NodeConsoleInfo,
 ) error {
 	m.consolesMu.Lock()
 	defer m.consolesMu.Unlock()
+	if m.shuttingDown {
+		return nil
+	}
 
-	// Stop the consoles of nodes that are no longer in the updated set.
-	for nodeID, cancel := range m.cancels {
-		if _, stillActive := sshNodes[nodeID]; !stillActive {
+	// Stop consoles for nodes that left inventory or are no longer SSH nodes.
+	for nodeID, console := range m.consoles {
+		info, present := nodes[nodeID]
+		if !present || info == nil || !info.IsSSH() {
 			slog.Info("Stopping SSH console", "nodeID", nodeID)
-			cancel()
+			console.cancel()
 			delete(m.consoles, nodeID)
-			delete(m.cancels, nodeID)
 		}
 	}
 
-	for nodeID, info := range sshNodes {
+	for nodeID, info := range nodes {
+		if info == nil || !info.IsSSH() {
+			continue
+		}
+
 		existing, exists := m.consoles[nodeID]
 		if !exists {
-			// nil credentials: the console parks until UpdateCredentials reaches it.
 			m.startConsole(ctx, nodeID, info, nil)
 			continue
 		}
 
 		if nodeChanged(existing.info, info) {
-			// Connection parameters changed — replace the console, carrying the
-			// credentials the old one was using.
+			// Preserve credentials when replacing the console.
 			slog.Info("SSH console node parameters changed, restarting", "nodeID", nodeID)
 			creds := existing.currentCreds()
-			m.cancels[nodeID]()
+			existing.cancel()
 			m.startConsole(ctx, nodeID, info, creds)
 		}
 	}
@@ -130,40 +111,44 @@ func (m *SSHConsoleManager) UpdateNodes(
 	return nil
 }
 
-// startConsole creates and starts the console for one node. Must be called with
-// consolesMu held. A nil creds means none have been fetched for this node yet.
+// startConsole creates and starts one console. Call with consolesMu held. Nil credentials delay
+// connection.
 func (m *SSHConsoleManager) startConsole(ctx context.Context, nodeID string, info *nodes.NodeConsoleInfo, creds *compcredentials.CompCredentials) {
 	consoleCtx, consoleCancel := context.WithCancel(ctx)
 	console := newSSHConsole(nodeID, info, creds, m.keyPath, m.logPath(nodeID), m.cfg, consoleCancel)
 	m.consoles[nodeID] = console
-	m.cancels[nodeID] = consoleCancel
 	slog.Info("Starting SSH console", "nodeID", nodeID, "host", info.ConnectionHost)
-	m.running.Add(1)
-	go func() {
-		defer m.running.Done()
+	m.running.Go(func() {
 		console.Run(consoleCtx)
-	}()
+	})
 }
 
-// Wait blocks until all console goroutines have stopped. The caller must first
-// cancel the context passed to UpdateNodes or remove every managed node.
+// Wait blocks until all Run goroutines exit but does not stop them. Callers cancel their contexts
+// first and then wait for log cleanup.
 func (m *SSHConsoleManager) Wait() {
 	m.running.Wait()
 }
 
-// UpdateCredentials delivers Vault entries to managed nodes, reconnecting any
-// node whose entry differs from the one it is using. It is the only way
-// credentials enter the manager; UpdateNodes never touches them.
-//
-// Only node IDs present in passwords are considered. An absent node is left
-// alone rather than cleared: a credential that has not arrived is not evidence
-// that a node has none, and a fetch can come back short for reasons that have
-// nothing to do with the node. A caller may therefore pass whatever it managed
-// to fetch without first deciding whether the result is complete.
-//
-// Moving a node from password to key auth is done by clearing the password on
-// its Vault entry, not by deleting the entry — the username is still needed
-// either way. That arrives here as a changed entry and is applied normally.
+// Shutdown stops all consoles and waits for their cleanup.
+func (m *SSHConsoleManager) Shutdown() {
+	m.consolesMu.Lock()
+	if !m.shuttingDown {
+		m.shuttingDown = true
+		for nodeID, console := range m.consoles {
+			slog.Info("Stopping SSH console", "nodeID", nodeID)
+			console.cancel()
+			delete(m.consoles, nodeID)
+		}
+	}
+	m.consolesMu.Unlock()
+
+	m.running.Wait()
+}
+
+// UpdateCredentials reconnects managed nodes whose credentials changed. UpdateNodes handles
+// membership and never changes authentication. Missing entries leave existing credentials
+// unchanged because reads may be partial, and entries for unmanaged nodes are ignored. An empty
+// password selects key authentication.
 func (m *SSHConsoleManager) UpdateCredentials(passwords map[string]compcredentials.CompCredentials) {
 	m.consolesMu.RLock()
 	type pending struct {
@@ -195,19 +180,18 @@ func (m *SSHConsoleManager) ReopenLogs() {
 	}
 }
 
-// Attach connects an interactive client to an SSH console node.
-// Returns an error if the node is not managed by this manager.
+// Attach connects a client and fails if the node is unmanaged.
 func (m *SSHConsoleManager) Attach(nodeID, clientID string) (chan []byte, error) {
 	m.consolesMu.RLock()
+	defer m.consolesMu.RUnlock()
 	console, ok := m.consoles[nodeID]
-	m.consolesMu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("SSH console node %q not found", nodeID)
 	}
 	return console.Attach(clientID), nil
 }
 
-// Detach disconnects a client from an SSH console node. No-op if not found.
+// Detach disconnects a client and ignores unmanaged nodes.
 func (m *SSHConsoleManager) Detach(nodeID, clientID string) {
 	m.consolesMu.RLock()
 	console, ok := m.consoles[nodeID]
@@ -217,9 +201,7 @@ func (m *SSHConsoleManager) Detach(nodeID, clientID string) {
 	}
 }
 
-// Write sends data to the SSH session stdin for a node. It returns an error if
-// the node is not managed by this manager, and ErrNotConnected if it is managed
-// but currently disconnected.
+// Write sends data to a node and distinguishes unmanaged nodes from temporary disconnections.
 func (m *SSHConsoleManager) Write(nodeID string, p []byte) (int, error) {
 	m.consolesMu.RLock()
 	console, ok := m.consoles[nodeID]

--- a/internal/ssh/manager_test.go
+++ b/internal/ssh/manager_test.go
@@ -21,8 +21,7 @@ import (
 	"github.com/OpenCHAMI/remote-console/internal/ssh"
 )
 
-// deadAddr returns a host:port that nothing is listening on, so connects to it
-// are refused immediately.
+// deadAddr returns an unused local address so connections fail immediately.
 func deadAddr(t *testing.T) string {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -36,12 +35,9 @@ func deadAddr(t *testing.T) string {
 	return addr
 }
 
-// TestWriteWhileDisconnectedReportsNotConnected pins the Write contract. A
-// managed node that has no live session must say so instead of returning
-// len(p), nil — that claimed the input had been delivered when it had been
-// thrown away, and the interactive session had no way to tell the difference.
-// The error is distinct from the not-found error because a caller should keep
-// going through a reconnect but not through a node that no longer exists.
+// TestWriteWhileDisconnectedReportsNotConnected verifies disconnected writes report no bytes.
+// This prevents discarded input from appearing delivered. ErrNotConnected remains distinct from
+// unmanaged node errors because reconnects are temporary.
 func TestWriteWhileDisconnectedReportsNotConnected(t *testing.T) {
 	id, nodeMap, passwords := singleNode(t, deadAddr(t))
 
@@ -66,8 +62,7 @@ func TestWriteWhileDisconnectedReportsNotConnected(t *testing.T) {
 	}
 }
 
-// waitForBytes reads from a session's recv channel until want appears or the
-// timeout expires.
+// waitForBytes reads until the expected session input arrives or the timeout expires.
 func waitForBytes(t *testing.T, sess *sshSession, want string, timeout time.Duration) {
 	t.Helper()
 	timer := time.NewTimer(timeout)
@@ -86,11 +81,8 @@ func waitForBytes(t *testing.T, sess *sshSession, want string, timeout time.Dura
 	}
 }
 
-// TestUpdateNodesPreservesCredentials pins the split between the two update
-// operations. UpdateNodes decides membership and nothing else; a healthy node
-// that survives the diff must keep running on the credentials it already has.
-// Clearing them would trigger UpdateCreds, drop the connection, and fall
-// through to key auth, which is not what this node uses.
+// TestUpdateNodesPreservesCredentials verifies membership updates retain active credentials.
+// Clearing credentials would drop a healthy session and incorrectly select key authentication.
 func TestUpdateNodesPreservesCredentials(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
@@ -102,10 +94,7 @@ func TestUpdateNodesPreservesCredentials(t *testing.T) {
 
 	startNodes(t, manager, ctx, nodeMap, passwords)
 
-	// Attach before the first connect completes. node.Write silently drops and
-	// reports success while stdin is nil, so writing before the node is fully
-	// wired up would race; the connected marker is broadcast after stdin is
-	// set, which makes it a reliable sync point.
+	// The connected marker confirms stdin is ready before the first write.
 	clientCh, err := manager.Attach(id, "creds-client")
 	if err != nil {
 		t.Fatal(err)
@@ -120,7 +109,6 @@ func TestUpdateNodesPreservesCredentials(t *testing.T) {
 	}
 	waitForBytes(t, sess, "before", 15*time.Second)
 
-	// Same node set — the node survives the diff untouched.
 	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
 		t.Fatal(err)
 	}
@@ -139,10 +127,8 @@ func TestUpdateNodesPreservesCredentials(t *testing.T) {
 	waitForBytes(t, sess, "after", 15*time.Second)
 }
 
-// TestUpdateNodesAddsAndRemovesNodes verifies that UpdateNodes adds and removes
-// nodes on its own, with no credentials in sight. Before the split, a failed
-// credential fetch skipped the SSH update entirely, so a node removed from
-// inventory kept its console running and a newly added node never started.
+// TestUpdateNodesAddsAndRemovesNodes verifies membership changes do not depend on credential
+// delivery. Inventory updates must proceed even when credentials are unavailable.
 func TestUpdateNodesAddsAndRemovesNodes(t *testing.T) {
 	srv := newSSHServer(t, func(ch gossh.Channel) { _ = ch.Close() })
 	id, nodeMap, _ := singleNode(t, srv.addr())
@@ -151,7 +137,7 @@ func TestUpdateNodesAddsAndRemovesNodes(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Add. The node must be registered so a later UpdateCredentials can reach it.
+	// Register the node before credentials arrive.
 	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +146,6 @@ func TestUpdateNodesAddsAndRemovesNodes(t *testing.T) {
 	}
 	manager.Detach(id, "probe")
 
-	// Remove.
 	if err := manager.UpdateNodes(ctx, map[string]*nodes.NodeConsoleInfo{}); err != nil {
 		t.Fatal(err)
 	}
@@ -169,13 +154,81 @@ func TestUpdateNodesAddsAndRemovesNodes(t *testing.T) {
 	}
 }
 
-// TestUpdateCredentialsIgnoresAbsentNodes pins the property that lets callers
-// pass a credential map they cannot vouch for. GetPasswords answers from a
-// snapshot that is only as complete as the last refresh, so an absent nodeID
-// says nothing about the node — only that the refresh did not bring it back.
-// UpdateCredentials must therefore leave absent nodes alone:
-// treating absence as a change would tear down a working console every time the
-// credential store had a bad minute.
+// TestShutdownStopsConsoles verifies shutdown removes consoles and prevents later updates from
+// restarting them.
+func TestShutdownStopsConsoles(t *testing.T) {
+	id, nodeMap, _ := singleNode(t, deadAddr(t))
+	manager := ssh.NewSSHConsoleManager(ssh.DefaultSSHConfig(), "", t.TempDir())
+
+	if err := manager.UpdateNodes(context.Background(), nodeMap); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Attach(id, "before-shutdown"); err != nil {
+		t.Fatalf("node was not registered before shutdown: %v", err)
+	}
+	manager.Detach(id, "before-shutdown")
+
+	manager.Shutdown()
+
+	if _, err := manager.Attach(id, "after-shutdown"); err == nil {
+		t.Fatal("node remained registered after shutdown")
+	}
+	if err := manager.UpdateNodes(context.Background(), nodeMap); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Attach(id, "after-update"); err == nil {
+		t.Fatal("node restarted after shutdown")
+	}
+}
+
+// TestUpdateNodesSelectsSSHNodesFromCompleteInventory verifies only SSH nodes are registered.
+// Changing a node away from SSH removes its console.
+func TestUpdateNodesSelectsSSHNodesFromCompleteInventory(t *testing.T) {
+	sshID, ipmiID := "x0c0s1b0", "x0c0s2b0"
+	allNodes := map[string]*nodes.NodeConsoleInfo{
+		sshID: {
+			ID:             sshID,
+			ConnectionType: nodes.SSH,
+			ConnectionHost: "127.0.0.1",
+			ConnectionPort: 1,
+		},
+		ipmiID: {
+			ID:             ipmiID,
+			ConnectionType: nodes.IPMI,
+			ConnectionHost: "127.0.0.1",
+		},
+	}
+
+	manager := newManager(t, t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := manager.UpdateNodes(ctx, allNodes); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Attach(sshID, "probe"); err != nil {
+		t.Fatalf("SSH node was not registered: %v", err)
+	}
+	manager.Detach(sshID, "probe")
+	if _, err := manager.Attach(ipmiID, "probe"); err == nil {
+		t.Fatal("IPMI node was registered by the SSH manager")
+	}
+
+	allNodes[sshID] = &nodes.NodeConsoleInfo{
+		ID:             sshID,
+		ConnectionType: nodes.IPMI,
+		ConnectionHost: "127.0.0.1",
+	}
+	if err := manager.UpdateNodes(ctx, allNodes); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Attach(sshID, "probe"); err == nil {
+		t.Fatal("node remained registered after changing from SSH to IPMI")
+	}
+}
+
+// TestUpdateCredentialsIgnoresAbsentNodes verifies partial snapshots do not disrupt working
+// consoles. A missing entry is not evidence of deletion, so existing credentials remain active.
 func TestUpdateCredentialsIgnoresAbsentNodes(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
@@ -196,7 +249,7 @@ func TestUpdateCredentialsIgnoresAbsentNodes(t *testing.T) {
 	sess := <-sessionCh
 	waitForMarker(t, clientCh, "[Console "+id+" connected at", 15*time.Second)
 
-	// An empty map — every node absent. Nothing may happen to this connection.
+	// An empty update must leave the connection unchanged.
 	manager.UpdateCredentials(map[string]compcredentials.CompCredentials{})
 
 	select {
@@ -212,11 +265,8 @@ func TestUpdateCredentialsIgnoresAbsentNodes(t *testing.T) {
 	waitForBytes(t, sess, "still-here", 15*time.Second)
 }
 
-// waitForLogMarker polls a node's console log file until it contains marker.
-//
-// Markers are broadcast to the log as well as to attached clients, which is
-// what makes this usable where an Attach would race: a node that says something
-// once, before any client could have attached, still leaves it on disk.
+// waitForLogMarker polls a node log until it contains marker. Logs retain markers emitted before
+// clients can attach, which avoids attachment timing races.
 func waitForLogMarker(t *testing.T, logsDir, nodeID, marker string, timeout time.Duration) {
 	t.Helper()
 	path := filepath.Join(logsDir, "console."+nodeID)
@@ -235,16 +285,9 @@ func waitForLogMarker(t *testing.T, logsDir, nodeID, marker string, timeout time
 	t.Fatalf("timeout waiting for %q in %s; log contains: %q", marker, path, string(last))
 }
 
-// TestNodeWithoutCredentialsWaitsInsteadOfDialling covers the provisioning
-// window. Every node in the cluster is expected to have a Vault entry — a
-// password node carries a username and password, a key node a username alone —
-// so an entry that has not arrived means it has not been written yet, not that
-// the node uses key auth.
-//
-// Dialling anyway would send an empty username at a real BMC and burn reconnect
-// attempts reporting an authentication problem, which is a misleading account
-// of a node that is merely early. The node must stay put, say so, and connect
-// once the entry reaches it.
+// TestNodeWithoutCredentialsWaitsInsteadOfDialling verifies provisioning nodes wait for a
+// credential entry. Every node requires a username, even for key authentication, so dialing
+// before the entry arrives would report a misleading authentication failure.
 func TestNodeWithoutCredentialsWaitsInsteadOfDialling(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
@@ -255,15 +298,14 @@ func TestNodeWithoutCredentialsWaitsInsteadOfDialling(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Membership only — no credentials follow.
+	// Register membership without credentials.
 	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
 		t.Fatal(err)
 	}
 
 	waitForLogMarker(t, logsDir, id, "waiting for credentials", 10*time.Second)
 
-	// Well past several reconnect intervals (250ms min, 1s max in tests), so a
-	// node that was going to dial would have done it by now.
+	// Wait beyond several reconnect intervals to detect an unintended dial.
 	time.Sleep(3 * time.Second)
 
 	if got := srv.accepts.Load(); got != 0 {
@@ -275,8 +317,7 @@ func TestNodeWithoutCredentialsWaitsInsteadOfDialling(t *testing.T) {
 	default:
 	}
 
-	// The entry arrives. The node must pick it up promptly rather than after
-	// some later poll — the wait is on a signal, not a timer.
+	// Credential delivery must wake the node without waiting for a timer.
 	manager.UpdateCredentials(passwords)
 
 	select {


### PR DESCRIPTION
Retain last-known credentials when a store read is partial while
dropping nodes that leave inventory. Pass complete views to the SSH
manager and shut it down before the HTTP service exits.

Signed-off-by: Chris Harris <cjh@lbl.gov>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>