### PR TITLE
feat(ssh): wait for provisioned credentials

### DIFF
--- a/cmd/remote-console/service.go
+++ b/cmd/remote-console/service.go
@@ -56,10 +56,9 @@ type LogsService interface {
 // the concrete *ssh.SSHConsoleManager is passed to console.SetupRoutes, which
 // uses it directly.
 type SSHConsoleService interface {
-	UpdateNodesAndCredentials(ctx context.Context, sshNodes map[string]*nodes.NodeConsoleInfo,
-		passwords map[string]compcreds.CompCredentials) error
 	UpdateNodes(ctx context.Context, sshNodes map[string]*nodes.NodeConsoleInfo) error
 	UpdateCredentials(passwords map[string]compcreds.CompCredentials)
+	NodesAwaitingCredentials() []string
 	ReopenLogs()
 }
 
@@ -94,10 +93,14 @@ func filterXNames(sshNodes map[string]*nodes.NodeConsoleInfo) []string {
 	return xnames
 }
 
-// Watch for node updates and signal conman and log rotation as needed
+// Watch for node updates and signal conman and log rotation as needed.
+//
+// This loop decides membership only. Credentials belong to watchForCredUpdates,
+// which picks up any node registered here that is still waiting for its Vault
+// entry — see SSHConsoleService.NodesAwaitingCredentials.
 func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpClient *http.Client,
 	conmanService ConmanService, logsService LogsService,
-	credsService CredsService, sshService SSHConsoleService) {
+	sshService SSHConsoleService) {
 	// ConMan writes console files in a conman subdirectory.
 	consoleLogsPath := filepath.Join(config.Log.ConsoleLogsBasePath, "conman")
 
@@ -116,40 +119,17 @@ func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpC
 				slog.Info("Node changes detected, reconfiguring services")
 
 				currentNodes := nodes.CurrentNodes()
-				passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(currentNodes), 15, 10)
-				if err != nil {
-					// passwords holds whatever the final attempt returned: possibly
-					// nil, possibly a partial map. An absent entry is then
-					// indistinguishable from a node that legitimately has no password
-					// and uses key auth, so neither consumer can read this map as the
-					// full picture.
-					//
-					// Skip the conman reconfigure — it interpolates credentials
-					// straight into conman.conf, and rewriting that from a partial map
-					// before SignalConmanTERM would drop working IPMI consoles. Apply
-					// the SSH node changes without credentials, so removed nodes
-					// still stop and added nodes still start while every existing
-					// node keeps the credentials it already has.
-					//
-					// This only catches the failed fetch. A fetch that exhausts its
-					// retries and returns a partial map with a nil error takes the
-					// branch below and reconfigures from incomplete credentials.
-					slog.Error("Failed to fetch credentials for updated nodes; skipping conman reconfigure, applying SSH node changes without credentials", "error", err)
-					if err := sshService.UpdateNodes(ctx, filterSSHNodes(currentNodes)); err != nil {
-						slog.Error("Failed to update SSH console nodes", "error", err)
-					}
-				} else {
-					// Regenerate conman config with the new node list and credentials.
-					if _, err := conmanService.ConfigureConman(filterIPMINodes(currentNodes), passwords); err != nil {
-						slog.Error("Failed to reconfigure conman", "error", err)
-					}
-					// Update SSH nodes with the current node set and credentials.
-					if err := sshService.UpdateNodesAndCredentials(ctx, filterSSHNodes(currentNodes), passwords); err != nil {
-						slog.Error("Failed to update SSH console manager", "error", err)
-					}
+
+				// Membership first: this is the only thing a node change is
+				// actually reporting, and it needs no credentials to apply.
+				sshNodes := filterSSHNodes(currentNodes)
+				if err := sshService.UpdateNodes(ctx, sshNodes); err != nil {
+					slog.Error("Failed to update SSH console nodes", "error", err)
 				}
 
-				// Restart conman to pick up the new config.
+				// conman needs no help here. runConman regenerates conman.conf
+				// from the current node set and a fresh credential fetch every
+				// time conmand exits, so signalling it is the whole job.
 				if err := conmanService.SignalConmanTERM(); err != nil {
 					slog.Error("Failed to signal conman with SIGTERM", "error", err)
 				}
@@ -168,7 +148,13 @@ func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpC
 	}
 }
 
-// Watch for credential updates and signal conman and SSH manager as needed
+// Watch for credential updates and signal conman and SSH manager as needed.
+//
+// This loop is the sole owner of credential delivery to the SSH manager. It has
+// two reasons to fetch: Vault changed, or a node registered by
+// watchForNodesUpdates has not received its entry yet. The second is what feeds
+// a node that joined the cluster after startup — nothing in Vault changed for
+// it, so change detection alone would leave it parked forever.
 func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig,
 	credsService CredsService, conmanService ConmanService, sshService SSHConsoleService) {
 	ticker := time.NewTicker(time.Duration(config.CredsMonitorInterval) * time.Second)
@@ -185,28 +171,41 @@ func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig,
 				slog.Error("Failed to check for credential updates", "error", err)
 			}
 
-			if changed {
-				slog.Info("Credential changes detected, reconfiguring services")
+			awaiting := sshService.NodesAwaitingCredentials()
+			if len(awaiting) > 0 {
+				slog.Info("SSH console nodes awaiting credentials", "count", len(awaiting))
+			}
 
-				currentNodes := nodes.CurrentNodes()
-				passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(currentNodes), 3, 5)
-				if err != nil {
-					// Same partial-map ambiguity as the node watch loop, but here
-					// skipping outright is the whole answer: no node joined or left,
-					// so there is no node change to apply and every node keeps
-					// running on the credentials it already has until a later fetch
-					// succeeds.
-					slog.Error("Failed to fetch updated credentials", "error", err)
-				} else {
-					// Regenerate conman config so IPMI nodes pick up the new credentials.
-					if _, err := conmanService.ConfigureConman(filterIPMINodes(currentNodes), passwords); err != nil {
-						slog.Error("Failed to reconfigure conman with updated credentials", "error", err)
+			if changed || len(awaiting) > 0 {
+				// Only the SSH manager needs the passwords here. conman picks
+				// the new ones up when runConman rebuilds conman.conf after the
+				// SIGTERM below.
+				sshNodes := filterSSHNodes(nodes.CurrentNodes())
+				if len(sshNodes) > 0 {
+					// Retry inside the call only when Vault reported a change,
+					// which means the entries are there to be read. When merely
+					// chasing nodes that are waiting, this ticker is the retry —
+					// an entry that has not been provisioned yet would otherwise
+					// burn the retry budget on every tick to learn the same thing.
+					tries, wait := 1, 0
+					if changed {
+						tries, wait = 3, 5
 					}
-					// Push updated credentials to SSH nodes.
+					passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(sshNodes), tries, wait)
+					if err != nil {
+						// Whatever came back is still worth applying: absent node
+						// IDs are left alone, so a partial map can only move nodes
+						// forward onto credentials that did arrive.
+						slog.Error("Failed to fetch updated credentials", "error", err)
+					}
 					sshService.UpdateCredentials(passwords)
 				}
+			}
 
-				// Always restart conman regardless of config update outcome.
+			// Restart conman only for a real credential change. A node waiting on
+			// its first Vault entry is no reason to drop every IPMI console.
+			if changed {
+				slog.Info("Credential changes detected, restarting conman")
 				if err := conmanService.SignalConmanTERM(); err != nil {
 					slog.Error("Failed to signal conman with SIGTERM", "error", err)
 				}
@@ -392,29 +391,11 @@ func runService(config remoteConsoleConfig) error {
 	// Create the SSH console manager.
 	sshManager := ssh.NewSSHConsoleManager(config.SSH, config.Creds.SshConsoleKeyPath, consoleLogsPath)
 
-	// Seed SSH nodes immediately — watchForNodesUpdates only fires after the first tick.
-	initialSSHNodes := filterSSHNodes(nodes.CurrentNodes())
-	if len(initialSSHNodes) > 0 {
-		initialXNames := filterXNames(initialSSHNodes)
-		passwords, err := credsService.GetPasswordsWithRetries(serviceCtx, initialXNames, 15, 10)
-		if err != nil {
-			// Start the nodes anyway. watchForNodesUpdates only reconfigures when
-			// inventory actually changes, so bailing out here would leave every
-			// SSH console dead until something in SMD happened to change.
-			slog.Warn("Failed to fetch initial SSH credentials, starting nodes without them", "error", err)
-			if err := sshManager.UpdateNodes(serviceCtx, initialSSHNodes); err != nil {
-				slog.Error("Failed initial SSH node update", "error", err)
-			}
-		} else if err := sshManager.UpdateNodesAndCredentials(serviceCtx, initialSSHNodes, passwords); err != nil {
-			slog.Error("Failed initial SSH manager node update", "error", err)
-		}
-	}
-
 	// goroutine for log rotation
 	go logRotate(serviceCtx, config, conmanService, logsService, sshManager)
 
 	// goroutine to watches for changes in console configuration
-	go watchForNodesUpdates(serviceCtx, config, smdHTTPClient, conmanService, logsService, credsService, sshManager)
+	go watchForNodesUpdates(serviceCtx, config, smdHTTPClient, conmanService, logsService, sshManager)
 
 	// goroutine to run conman
 	go runConman(serviceCtx, conmanService, credsService)

--- a/internal/ssh/auth_test.go
+++ b/internal/ssh/auth_test.go
@@ -1,0 +1,179 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package ssh
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	compcredentials "github.com/Cray-HPE/hms-compcredentials"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+func writeTestPrivateKey(t *testing.T, path string) gossh.Signer {
+	t.Helper()
+
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := gossh.MarshalPrivateKey(privateKey, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0600); err != nil {
+		t.Fatal(err)
+	}
+	signer, err := gossh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signer
+}
+
+func writeTestCertificate(t *testing.T, path string, key gossh.PublicKey) {
+	t.Helper()
+
+	_, caPrivateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caSigner, err := gossh.NewSignerFromKey(caPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert := &gossh.Certificate{
+		Key:         key,
+		CertType:    gossh.UserCert,
+		KeyId:       "test",
+		ValidBefore: gossh.CertTimeInfinity,
+	}
+	if err := cert.SignCert(rand.Reader, caSigner); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, gossh.MarshalAuthorizedKey(cert), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildAuth(t *testing.T) {
+	t.Run("password takes priority", func(t *testing.T) {
+		console := &SSHConsole{nodeID: "node", keyPath: filepath.Join(t.TempDir(), "missing")}
+		methods, err := console.buildAuth(compcredentials.CompCredentials{Password: "password"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(methods) != 1 {
+			t.Fatalf("got %d auth methods, want 1", len(methods))
+		}
+	})
+
+	t.Run("missing key path", func(t *testing.T) {
+		console := &SSHConsole{nodeID: "node"}
+		_, err := console.buildAuth(compcredentials.CompCredentials{})
+		if err == nil || !strings.Contains(err.Error(), "no key path configured") {
+			t.Fatalf("got %v, want missing key path error", err)
+		}
+	})
+
+	t.Run("missing key file", func(t *testing.T) {
+		console := &SSHConsole{nodeID: "node", keyPath: filepath.Join(t.TempDir(), "missing")}
+		_, err := console.buildAuth(compcredentials.CompCredentials{})
+		if err == nil || !strings.Contains(err.Error(), "read SSH key") {
+			t.Fatalf("got %v, want key read error", err)
+		}
+	})
+
+	t.Run("invalid private key", func(t *testing.T) {
+		keyPath := filepath.Join(t.TempDir(), "console.key")
+		if err := os.WriteFile(keyPath, []byte("invalid"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		console := &SSHConsole{nodeID: "node", keyPath: keyPath}
+		_, err := console.buildAuth(compcredentials.CompCredentials{})
+		if err == nil || !strings.Contains(err.Error(), "parse SSH private key") {
+			t.Fatalf("got %v, want private key parse error", err)
+		}
+	})
+
+	t.Run("key only", func(t *testing.T) {
+		keyPath := filepath.Join(t.TempDir(), "console.key")
+		writeTestPrivateKey(t, keyPath)
+		console := &SSHConsole{nodeID: "node", keyPath: keyPath}
+		methods, err := console.buildAuth(compcredentials.CompCredentials{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(methods) != 1 {
+			t.Fatalf("got %d auth methods, want 1", len(methods))
+		}
+	})
+
+	t.Run("invalid certificate", func(t *testing.T) {
+		keyPath := filepath.Join(t.TempDir(), "console.key")
+		writeTestPrivateKey(t, keyPath)
+		if err := os.WriteFile(keyPath+"-cert.pub", []byte("invalid"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		console := &SSHConsole{nodeID: "node", keyPath: keyPath}
+		_, err := console.buildAuth(compcredentials.CompCredentials{})
+		if err == nil || !strings.Contains(err.Error(), "parse SSH certificate") {
+			t.Fatalf("got %v, want certificate parse error", err)
+		}
+	})
+
+	t.Run("public key is not a certificate", func(t *testing.T) {
+		keyPath := filepath.Join(t.TempDir(), "console.key")
+		signer := writeTestPrivateKey(t, keyPath)
+		if err := os.WriteFile(keyPath+"-cert.pub", gossh.MarshalAuthorizedKey(signer.PublicKey()), 0644); err != nil {
+			t.Fatal(err)
+		}
+		console := &SSHConsole{nodeID: "node", keyPath: keyPath}
+		_, err := console.buildAuth(compcredentials.CompCredentials{})
+		if err == nil || !strings.Contains(err.Error(), "is not an SSH certificate") {
+			t.Fatalf("got %v, want certificate type error", err)
+		}
+	})
+
+	t.Run("certificate key mismatch", func(t *testing.T) {
+		keyPath := filepath.Join(t.TempDir(), "console.key")
+		writeTestPrivateKey(t, keyPath)
+		_, otherPrivateKey, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		otherSigner, err := gossh.NewSignerFromKey(otherPrivateKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeTestCertificate(t, keyPath+"-cert.pub", otherSigner.PublicKey())
+
+		console := &SSHConsole{nodeID: "node", keyPath: keyPath}
+		_, err = console.buildAuth(compcredentials.CompCredentials{})
+		if err == nil || !strings.Contains(err.Error(), "create cert signer") {
+			t.Fatalf("got %v, want certificate signer error", err)
+		}
+	})
+
+	t.Run("certificate", func(t *testing.T) {
+		keyPath := filepath.Join(t.TempDir(), "console.key")
+		signer := writeTestPrivateKey(t, keyPath)
+		writeTestCertificate(t, keyPath+"-cert.pub", signer.PublicKey())
+
+		console := &SSHConsole{nodeID: "node", keyPath: keyPath}
+		methods, err := console.buildAuth(compcredentials.CompCredentials{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(methods) != 1 {
+			t.Fatalf("got %d auth methods, want 1", len(methods))
+		}
+	})
+}

--- a/internal/ssh/concurrent_test.go
+++ b/internal/ssh/concurrent_test.go
@@ -22,20 +22,9 @@ import (
 )
 
 // TestSSHConsoleManagerConcurrent exercises concurrent access to SSHConsoleManager
-// and SSHConsoleNode. Run with -race to catch synchronisation bugs:
+// and SSHConsole.
 //
 //	go test -race -v -run TestSSHConsoleManagerConcurrent ./internal/ssh/ -timeout 60s
-//
-// Workers run simultaneously for concurrentDuration, each hammering a different
-// surface area:
-//
-//	attachWorker  – Attach, drain a few bytes, Detach (stresses clientsMu)
-//	writeWorker   – Write to random nodes while connections may be tearing down
-//	                (stresses connMu)
-//	credsWorker   – UpdateCredentials in a tight loop (stresses credsMu + connMu)
-//	rotateWorker  – ReopenLogs repeatedly (stresses reopenLogCh vs broadcast)
-//	updateWorker  – UpdateNodesAndCredentials with a shifting node set (stresses nodesMu vs
-//	                everything else)
 const (
 	concurrentNodes    = 100
 	concurrentWorkers  = 20
@@ -83,9 +72,7 @@ func TestSSHConsoleManagerConcurrent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
-		t.Fatalf("initial UpdateNodesAndCredentials: %v", err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
 	// Wait until all nodes are registered (Attach succeeds) before starting workers.
 	deadline := time.Now().Add(30 * time.Second)
@@ -110,12 +97,11 @@ func TestSSHConsoleManagerConcurrent(t *testing.T) {
 	end := time.Now().Add(concurrentDuration)
 	var wg sync.WaitGroup
 
-	// attachWorker: Attach → drain a few messages → Detach in a tight loop.
+	// attachWorker repeatedly attaches, drains output, and detaches.
 	// Stresses clientsMu against broadcast from the Run goroutine.
 	for i := 0; i < concurrentWorkers; i++ {
-		wg.Add(1)
-		go func(workerID int) {
-			defer wg.Done()
+		workerID := i
+		wg.Go(func() {
 			rng := rand.New(rand.NewSource(int64(workerID)))
 			clientID := fmt.Sprintf("attach-worker-%d", workerID)
 			for time.Now().Before(end) {
@@ -139,69 +125,55 @@ func TestSSHConsoleManagerConcurrent(t *testing.T) {
 				}
 				manager.Detach(id, clientID)
 			}
-		}(i)
+		})
 	}
 
-	// writeWorker: Write to random nodes.
+	// writeWorker writes to random nodes.
 	// Stresses connMu against connect/disconnect cycling.
 	for i := 0; i < concurrentWorkers; i++ {
-		wg.Add(1)
-		go func(workerID int) {
-			defer wg.Done()
+		workerID := i
+		wg.Go(func() {
 			rng := rand.New(rand.NewSource(int64(workerID + 1000)))
 			payload := fmt.Appendf(nil, "worker-%d-ping\r\n", workerID)
 			for time.Now().Before(end) {
 				id := allIDs[rng.Intn(len(allIDs))]
 				if _, err := manager.Write(id, payload); err != nil {
-					// Node removed — not a bug.
+					// Node removal is expected.
 					time.Sleep(time.Millisecond)
 				}
 			}
-		}(i)
+		})
 	}
 
-	// credsWorker: UpdateCredentials in a tight loop.
-	// Stresses credsMu and the connMu path inside UpdateCreds.
-	//
-	// The passwords must actually differ between calls. If they are identical,
-	// credsChanged() is always false, UpdateCreds() is never reached, and the
-	// worker silently tests nothing — which is how a data race between
-	// UpdateCredentials' read of node.creds and UpdateCreds' write went
-	// unnoticed here. Both values authenticate, so nodes still connect.
+	// credsWorker alternates valid passwords to exercise UpdateCreds locking.
 	credSets := []map[string]compcredentials.CompCredentials{
 		makePasswordsWith(allIDs, testSSHPass),
 		makePasswordsWith(allIDs, testSSHPassAlt),
 	}
 	for i := 0; i < concurrentWorkers/2; i++ {
-		wg.Add(1)
-		go func(workerID int) {
-			defer wg.Done()
+		wg.Go(func() {
 			for round := 0; time.Now().Before(end); round++ {
 				manager.UpdateCredentials(credSets[round%len(credSets)])
 				time.Sleep(5 * time.Millisecond)
 			}
-		}(i)
+		})
 	}
 
-	// rotateWorker: Signal log rotation.
+	// rotateWorker repeatedly reopens logs.
 	// Stresses the reopenLogCh non-blocking send against broadcast.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for time.Now().Before(end) {
 			manager.ReopenLogs()
 			time.Sleep(10 * time.Millisecond)
 		}
-	}()
+	})
 
-	// updateWorker: Shuffle the node set — remove a few nodes and restore them.
-	// Stresses nodesMu against Attach/Detach/Write happening concurrently.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	// updateWorker removes and restores nodes.
+	// Stresses consolesMu against Attach/Detach/Write happening concurrently.
+	wg.Go(func() {
 		rng := rand.New(rand.NewSource(42))
 		for time.Now().Before(end) {
-			// Drop 1–3 nodes.
+			// Drop one to three nodes.
 			drop := rng.Intn(3) + 1
 			skipIdx := make(map[int]bool, drop)
 			for len(skipIdx) < drop {
@@ -214,18 +186,20 @@ func TestSSHConsoleManagerConcurrent(t *testing.T) {
 				}
 			}
 			subMap := makeNodeMap(subset)
-			if err := manager.UpdateNodesAndCredentials(ctx, subMap, makePasswords(subset)); err != nil {
-				t.Errorf("UpdateNodesAndCredentials (subset): %v", err)
+			if err := manager.UpdateNodes(ctx, subMap); err != nil {
+				t.Errorf("UpdateNodes (subset): %v", err)
 			}
+			manager.UpdateCredentials(makePasswords(subset))
 			time.Sleep(20 * time.Millisecond)
 
 			// Restore the full set.
-			if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
-				t.Errorf("UpdateNodesAndCredentials (full): %v", err)
+			if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
+				t.Errorf("UpdateNodes (full): %v", err)
 			}
+			manager.UpdateCredentials(passwords)
 			time.Sleep(20 * time.Millisecond)
 		}
-	}()
+	})
 
 	wg.Wait()
 

--- a/internal/ssh/console.go
+++ b/internal/ssh/console.go
@@ -6,6 +6,7 @@ package ssh
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -21,80 +22,83 @@ import (
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
 )
 
+// errNoCredentials means no credential entry has reached this node.
+// Run waits instead of dialing when credentials are unavailable.
+var errNoCredentials = errors.New("no credentials available for node")
+
 // consoleClient is one attached interactive client.
 type consoleClient struct {
 	ch chan []byte
-	// dropped counts bytes discarded because ch was full since the last drop
-	// notice this client was given. A console that silently skips output is
-	// worse than one that admits to a gap — an operator reading back a boot log
-	// has no other way to tell that something was cut.
+	// dropped counts bytes discarded since the last notice.
 	dropped int
 }
 
-// SSHConsoleNode manages a single persistent SSH console connection.
-// Its Run goroutine is the sole writer for the log file and client channels —
-// no lock is needed for those writes.
-type SSHConsoleNode struct {
+// SSHConsole manages one SSH node and persists across connections.
+// Run owns log and client channel writes and reconnects until cancelled.
+type SSHConsole struct {
 	nodeID  string
 	info    *nodes.NodeConsoleInfo
 	keyPath string
 	cfg     SSHConfig
 
+	// credsMu protects creds. Nil means no credential entry has arrived.
+	// An empty password may still select key authentication.
 	credsMu sync.RWMutex
-	creds   compcredentials.CompCredentials
+	creds   *compcredentials.CompCredentials
+	// credsCh wakes Run when credentials arrive.
+	credsCh chan struct{}
 
-	// clientsMu protects the clients map and the consoleClient values in it.
-	// broadcast takes it for writing because it updates each client's drop
-	// accounting; Attach and Detach are rare enough that the lost read
-	// concurrency does not matter.
-	// Lock ordering: nodesMu (manager) → clientsMu → connMu
-	clientsMu sync.RWMutex
-	clients   map[string]*consoleClient // channel closed and entry deleted on Detach or Run exit
+	// clientsMu protects clients and their drop counts.
+	// Locks are acquired in the order consolesMu, clientsMu, then connMu.
+	clientsMu sync.Mutex
+	clients   map[string]*consoleClient // closed on detach or shutdown
 
 	// connMu protects sshClient and stdin.
 	connMu    sync.Mutex
 	sshClient *gossh.Client
 	stdin     io.WriteCloser
 
-	// stdinMu serializes Write calls. golang.org/x/crypto/ssh reuses a per-channel
-	// packet buffer (packetPool) across WriteExtended calls, so concurrent writes
-	// to the same stdin pipe race. Multiple interactive clients may call Write
-	// simultaneously; this mutex ensures they are serialized.
-	stdinMu sync.Mutex
+	// writeMu serializes writes because SSH reuses a channel packet buffer.
+	// Multiple interactive clients may write concurrently.
+	writeMu sync.Mutex
 
-	// logFile is opened at the start of Run and written only from the Run goroutine.
-	logFile     *os.File
-	logPath     string        // logsPath + "/console." + nodeID
-	reopenLogCh chan struct{} // buffered depth-1; signals broadcast to reopen after rotation
+	// logFile is written only by Run.
+	logFile      *os.File
+	logPath      string
+	reopenLogCh  chan struct{} // buffered rotation signal
+	logFormatter consoleLogFormatter
 
-	// cancel is called by the manager to stop the Run goroutine.
-	// ctx is NOT stored in the struct to avoid the go vet context-in-struct antipattern.
+	// cancel stops Run without storing its context.
 	cancel context.CancelFunc
 }
 
-// newSSHConsoleNode constructs an SSHConsoleNode. The caller (manager) must set
-// node.cancel and call go node.Run(nodeCtx) after construction.
-func newSSHConsoleNode(nodeID string, info *nodes.NodeConsoleInfo, creds compcredentials.CompCredentials, keyPath, logPath string, cfg SSHConfig) *SSHConsoleNode {
-	return &SSHConsoleNode{
-		nodeID:      nodeID,
-		info:        info,
-		keyPath:     keyPath,
-		cfg:         cfg,
-		creds:       creds,
-		clients:     make(map[string]*consoleClient),
-		logPath:     logPath,
-		reopenLogCh: make(chan struct{}, 1),
+// newSSHConsole constructs an SSHConsole.
+// Nil credentials delay connection.
+func newSSHConsole(nodeID string, info *nodes.NodeConsoleInfo, creds *compcredentials.CompCredentials, keyPath, logPath string, cfg SSHConfig, cancel context.CancelFunc) *SSHConsole {
+	return &SSHConsole{
+		nodeID:       nodeID,
+		info:         info,
+		keyPath:      keyPath,
+		cfg:          cfg,
+		creds:        cloneCreds(creds),
+		clients:      make(map[string]*consoleClient),
+		logPath:      logPath,
+		reopenLogCh:  make(chan struct{}, 1),
+		logFormatter: newConsoleLogFormatter(),
+		credsCh:      make(chan struct{}, 1),
+		cancel:       cancel,
 	}
 }
 
 // streamStdout reads from the SSH session stdout and broadcasts to all clients
 // until the connection drops.
-func (n *SSHConsoleNode) streamStdout(stdout io.Reader) {
+func (c *SSHConsole) streamStdout(stdout io.Reader) {
+	// Match the default buffer size used by io.Copy.
 	buf := make([]byte, 32*1024)
 	for {
 		nr, err := stdout.Read(buf)
 		if nr > 0 {
-			n.broadcast(buf[:nr])
+			c.broadcast(buf[:nr])
 		}
 		if err != nil {
 			break
@@ -102,17 +106,16 @@ func (n *SSHConsoleNode) streamStdout(stdout io.Reader) {
 	}
 }
 
-// connectAndStream attempts one connection, streams output until disconnect,
-// then cleans up. Returns true if the connection was established (used by Run
-// to reset the backoff on successful connects).
-func (n *SSHConsoleNode) connectAndStream(ctx context.Context) bool {
-	stdout, err := n.connect(ctx)
+// connectAndStream streams one connection and then cleans it up.
+// It reports whether the connection was established.
+func (c *SSHConsole) connectAndStream(ctx context.Context) bool {
+	stdout, err := c.connect(ctx)
 	if err != nil {
 		if ctx.Err() != nil {
 			return false
 		}
-		slog.Error("SSH console connect failed", "nodeID", n.nodeID, "error", err)
-		n.broadcast([]byte(fmt.Sprintf("\n[Console %s connect failed: %v]\n", n.nodeID, err)))
+		slog.Error("SSH console connect failed", "nodeID", c.nodeID, "error", err)
+		c.broadcast([]byte(fmt.Sprintf("\n[Console %s connect failed: %v]\n", c.nodeID, err)))
 		return false
 	}
 
@@ -123,36 +126,35 @@ func (n *SSHConsoleNode) connectAndStream(ctx context.Context) bool {
 	go func() {
 		select {
 		case <-ctx.Done():
-			n.connMu.Lock()
-			if n.sshClient != nil {
-				_ = n.sshClient.Close()
+			c.connMu.Lock()
+			if c.sshClient != nil {
+				_ = c.sshClient.Close()
 			}
-			n.connMu.Unlock()
+			c.connMu.Unlock()
 		case <-ctxDone:
 		}
 	}()
 
-	n.streamStdout(stdout)
+	c.streamStdout(stdout)
 
-	// Clean up the connection. Nil stdin under connMu so Write sees nil and
-	// reports ErrNotConnected, then close it under stdinMu so an in-flight Write
-	// cannot race with Close on the underlying SSH channel buffer.
-	n.connMu.Lock()
-	if n.sshClient != nil {
-		_ = n.sshClient.Close()
-		n.sshClient = nil
+	// Clear stdin before closing it so Write reports ErrNotConnected.
+	// writeMu prevents Close from racing with an active Write.
+	c.connMu.Lock()
+	if c.sshClient != nil {
+		_ = c.sshClient.Close()
+		c.sshClient = nil
 	}
-	stdin := n.stdin
-	n.stdin = nil
-	n.connMu.Unlock()
+	stdin := c.stdin
+	c.stdin = nil
+	c.connMu.Unlock()
 	if stdin != nil {
-		n.stdinMu.Lock()
+		c.writeMu.Lock()
 		_ = stdin.Close()
-		n.stdinMu.Unlock()
+		c.writeMu.Unlock()
 	}
 
-	n.broadcast([]byte(fmt.Sprintf("\n[Console %s disconnected at %s]\n",
-		n.nodeID, time.Now().Format(time.RFC3339))))
+	c.broadcast([]byte(fmt.Sprintf("\n[Console %s disconnected at %s]\n",
+		c.nodeID, time.Now().Format(time.RFC3339))))
 	return true
 }
 
@@ -160,9 +162,8 @@ func (n *SSHConsoleNode) connectAndStream(ctx context.Context) bool {
 // backoff is considered recovered and reset to ReconnectMinInterval.
 const stableConnection = 30 * time.Second
 
-// jitter returns d scaled by a random factor in [0.5, 1.0). Without it, a
-// network blip reconnects every node at the same instant — at the scale this
-// manager targets that is a thundering herd against the BMC network.
+// jitter spreads retries across the latter half of d.
+// This avoids simultaneous reconnects after a network failure.
 func jitter(d time.Duration) time.Duration {
 	if d <= 0 {
 		return 0
@@ -170,47 +171,30 @@ func jitter(d time.Duration) time.Duration {
 	return d/2 + time.Duration(rand.Int64N(int64(d/2)+1))
 }
 
-// Run is the main loop for the node. It connects, reads output, fans it out,
-// and reconnects on disconnect.
-//
-// It exits only when ctx is cancelled. The manager owns that ctx and cancels it
-// when the node leaves inventory, which makes the manager the single authority
-// on node lifetime. Run must not decide to stop on its own: the manager would
-// keep the node in its map with no goroutine behind it, so Attach would hand
-// back a channel that never delivers and no later update would revive it (the
-// node still "exists" and its parameters are unchanged).
-func (n *SSHConsoleNode) Run(ctx context.Context) {
+// Run connects, broadcasts output, and reconnects until cancelled.
+// The manager controls its lifetime and must not retain a stopped console.
+func (c *SSHConsole) Run(ctx context.Context) {
 	var err error
-	n.logFile, err = os.OpenFile(n.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+	c.logFile, err = os.OpenFile(c.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
-		slog.Error("Failed to open SSH console log file", "nodeID", n.nodeID, "path", n.logPath, "error", err)
-		// Continue with nil logFile; broadcast skips write when nil.
+		slog.Error("Failed to open SSH console log file", "nodeID", c.nodeID, "path", c.logPath, "error", err)
+		// Continue without logging.
 	}
 	defer func() {
-		if n.logFile != nil {
-			_ = n.logFile.Close()
+		if c.logFile != nil {
+			_ = c.logFile.Close()
 		}
 		// Close and delete all client channels so streamOutput goroutines
 		// see ok=false and exit cleanly.
-		n.clientsMu.Lock()
-		for id, c := range n.clients {
-			close(c.ch)
-			delete(n.clients, id)
+		c.clientsMu.Lock()
+		for id, client := range c.clients {
+			close(client.ch)
+			delete(c.clients, id)
 		}
-		n.clientsMu.Unlock()
+		c.clientsMu.Unlock()
 	}()
 
-	// Backstop against a config that never went through SSHConfig.Validate —
-	// a directly-constructed zero value would otherwise spin this loop with no
-	// wait between reconnects. Not a substitute for validation; just a floor so
-	// a programming error can't hammer the BMC network.
-	minBackoff := n.cfg.ReconnectMinInterval
-	if minBackoff < minReconnectInterval {
-		slog.Warn("SSH reconnect interval below minimum, clamping",
-			"nodeID", n.nodeID, "configured", minBackoff, "using", minReconnectInterval)
-		minBackoff = minReconnectInterval
-	}
-	backoff := minBackoff
+	backoff := c.cfg.ReconnectMinInterval
 
 	for {
 		select {
@@ -219,15 +203,26 @@ func (n *SSHConsoleNode) Run(ctx context.Context) {
 		default:
 		}
 
-		start := time.Now()
-		connected := n.connectAndStream(ctx)
+		// Wait for a credential entry before dialing.
+		// An empty password may select key authentication after it arrives.
+		if c.currentCreds() == nil {
+			slog.Info("SSH console node waiting for credentials", "nodeID", c.nodeID)
+			c.broadcast([]byte(fmt.Sprintf("\n[Console %s waiting for credentials]\n", c.nodeID)))
+			select {
+			case <-ctx.Done():
+				return
+			case <-c.credsCh:
+			}
+			continue
+		}
 
-		// Only reset the backoff for a connection that actually held up. A host
-		// that accepts, authenticates, then immediately drops (bad entry command,
-		// session limit) would otherwise reset every cycle and be hammered at
-		// ReconnectMinInterval indefinitely.
+		start := time.Now()
+		connected := c.connectAndStream(ctx)
+
+		// Reset backoff only after a stable connection.
+		// Immediate disconnects continue backing off.
 		if connected && time.Since(start) >= stableConnection {
-			backoff = minBackoff
+			backoff = c.cfg.ReconnectMinInterval
 		}
 
 		select {
@@ -237,55 +232,65 @@ func (n *SSHConsoleNode) Run(ctx context.Context) {
 		}
 
 		backoff *= 2
-		if backoff > n.cfg.ReconnectMaxInterval {
-			backoff = n.cfg.ReconnectMaxInterval
+		if backoff > c.cfg.ReconnectMaxInterval {
+			backoff = c.cfg.ReconnectMaxInterval
 		}
 	}
 }
 
-// currentCreds returns a snapshot of the node's credentials under credsMu.
-// All reads of n.creds — including from the manager — must go through this.
-func (n *SSHConsoleNode) currentCreds() compcredentials.CompCredentials {
-	n.credsMu.RLock()
-	defer n.credsMu.RUnlock()
-	return n.creds
+// currentCreds returns a copy of the credentials under credsMu.
+// Nil means no credential entry has arrived.
+func (c *SSHConsole) currentCreds() *compcredentials.CompCredentials {
+	c.credsMu.RLock()
+	defer c.credsMu.RUnlock()
+	return cloneCreds(c.creds)
+}
+
+// cloneCreds copies a nil-able credential so the original cannot be aliased.
+func cloneCreds(creds *compcredentials.CompCredentials) *compcredentials.CompCredentials {
+	if creds == nil {
+		return nil
+	}
+	c := *creds
+	return &c
 }
 
 // dialClient reads credentials, dials TCP, and completes the SSH handshake.
-func (n *SSHConsoleNode) dialClient(ctx context.Context) (*gossh.Client, error) {
-	creds := n.currentCreds()
+func (c *SSHConsole) dialClient(ctx context.Context) (*gossh.Client, error) {
+	creds := c.currentCreds()
+	if creds == nil {
+		return nil, errNoCredentials
+	}
 
-	auth, err := n.buildAuth(creds)
+	auth, err := c.buildAuth(*creds)
 	if err != nil {
 		return nil, fmt.Errorf("build SSH auth: %w", err)
 	}
 
-	port := n.info.ConnectionPort
+	port := c.info.ConnectionPort
 	if port == 0 {
 		port = 22
 	}
-	addr := fmt.Sprintf("%s:%d", n.info.ConnectionHost, port)
+	addr := fmt.Sprintf("%s:%d", c.info.ConnectionHost, port)
 
-	dialer := &net.Dialer{Timeout: n.cfg.ConnectTimeout}
-	if n.cfg.TCPKeepAlive > 0 {
-		dialer.KeepAlive = n.cfg.TCPKeepAlive
+	dialer := &net.Dialer{Timeout: c.cfg.ConnectTimeout}
+	if c.cfg.TCPKeepAlive > 0 {
+		dialer.KeepAlive = c.cfg.TCPKeepAlive
 	}
 	netConn, err := dialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("dial %s: %w", addr, err)
 	}
 
-	// gossh.NewClientConn neither takes a context nor honours ClientConfig.Timeout
-	// (that field is only consulted by gossh.Dial for the TCP dial), so a host that
-	// completes the TCP handshake but stalls the SSH one would block here forever.
-	// Guard it with both an absolute deadline and a ctx watchdog that closes the
-	// conn, so shutdown is not held up either.
-	if err := netConn.SetDeadline(time.Now().Add(n.cfg.ConnectTimeout)); err != nil {
+	// NewClientConn has no context and ignores ClientConfig.Timeout.
+	// Bound the handshake with a deadline and close it on cancellation.
+	if err := netConn.SetDeadline(time.Now().Add(c.cfg.ConnectTimeout)); err != nil {
 		_ = netConn.Close()
 		return nil, fmt.Errorf("set handshake deadline for %s: %w", addr, err)
 	}
 	handshakeDone := make(chan struct{})
 	defer close(handshakeDone)
+	// Cancel the handshake if the context is cancelled
 	go func() {
 		select {
 		case <-ctx.Done():
@@ -297,15 +302,14 @@ func (n *SSHConsoleNode) dialClient(ctx context.Context) (*gossh.Client, error) 
 	sshConn, chans, reqs, err := gossh.NewClientConn(netConn, addr, &gossh.ClientConfig{
 		User:            creds.Username,
 		Auth:            auth,
-		HostKeyCallback: gossh.InsecureIgnoreHostKey(), //nolint:gosec // BMC management network; matches existing StrictHostKeyChecking=no
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(), //nolint:gosec // Matches existing BMC host key behavior
 	})
 	if err != nil {
 		_ = netConn.Close()
 		return nil, fmt.Errorf("SSH handshake with %s: %w", addr, err)
 	}
 
-	// Clear the handshake deadline — the session is long-lived and must not
-	// inherit it. Liveness from here on is TCP keepalives.
+	// Clear the handshake deadline before starting the long-lived session.
 	if err := netConn.SetDeadline(time.Time{}); err != nil {
 		_ = sshConn.Close()
 		return nil, fmt.Errorf("clear handshake deadline for %s: %w", addr, err)
@@ -314,18 +318,24 @@ func (n *SSHConsoleNode) dialClient(ctx context.Context) (*gossh.Client, error) 
 	return gossh.NewClient(sshConn, chans, reqs), nil
 }
 
+const (
+	terminalRows     = 24
+	terminalColumns  = 80
+	terminalBaudRate = 115200
+)
+
 // startSession opens a PTY session on client, wires up stdout/stdin pipes, and
 // starts the shell or entry command. Returns stdout and stdin on success.
-func (n *SSHConsoleNode) startSession(client *gossh.Client) (stdout io.Reader, stdin io.WriteCloser, err error) {
+func (c *SSHConsole) startSession(client *gossh.Client) (stdout io.Reader, stdin io.WriteCloser, err error) {
 	session, err := client.NewSession()
 	if err != nil {
 		return nil, nil, fmt.Errorf("new SSH session: %w", err)
 	}
 
-	if err := session.RequestPty(n.cfg.TerminalType, 24, 80, gossh.TerminalModes{
+	if err := session.RequestPty(c.cfg.TerminalType, terminalRows, terminalColumns, gossh.TerminalModes{
 		gossh.ECHO:          1,
-		gossh.TTY_OP_ISPEED: 115200, // matches conman seropts="115200,8n1"
-		gossh.TTY_OP_OSPEED: 115200,
+		gossh.TTY_OP_ISPEED: terminalBaudRate,
+		gossh.TTY_OP_OSPEED: terminalBaudRate,
 	}); err != nil {
 		_ = session.Close()
 		return nil, nil, fmt.Errorf("request PTY: %w", err)
@@ -343,10 +353,10 @@ func (n *SSHConsoleNode) startSession(client *gossh.Client) (stdout io.Reader, s
 		return nil, nil, fmt.Errorf("stdin pipe: %w", err)
 	}
 
-	if n.info.ConsoleEntryCommand == "" {
+	if c.info.ConsoleEntryCommand == "" {
 		err = session.Shell()
 	} else {
-		err = session.Start(n.info.ConsoleEntryCommand)
+		err = session.Start(c.info.ConsoleEntryCommand)
 	}
 	if err != nil {
 		_ = session.Close()
@@ -356,80 +366,75 @@ func (n *SSHConsoleNode) startSession(client *gossh.Client) (stdout io.Reader, s
 	// Reap the session when it ends to release server-side resources.
 	go func() {
 		if err := session.Wait(); err != nil {
-			slog.Debug("SSH session ended", "nodeID", n.nodeID, "error", err)
+			slog.Debug("SSH session ended", "nodeID", c.nodeID, "error", err)
 		}
 	}()
 
 	return stdout, stdin, nil
 }
 
-// connect dials the remote host, opens a PTY session, and stores connection
-// state. Returns the stdout reader on success; caller must drain it until
-// error/EOF.
-func (n *SSHConsoleNode) connect(ctx context.Context) (io.Reader, error) {
-	client, err := n.dialClient(ctx)
+// connect opens a PTY session and stores its connection state.
+// The caller drains stdout until EOF or error.
+func (c *SSHConsole) connect(ctx context.Context) (io.Reader, error) {
+	client, err := c.dialClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Track whether connect succeeds so the defer can clean up on failure.
 	success := false
 	defer func() {
 		if !success {
-			n.connMu.Lock()
-			n.sshClient = nil
-			n.stdin = nil
-			n.connMu.Unlock()
+			c.connMu.Lock()
+			c.sshClient = nil
+			c.stdin = nil
+			c.connMu.Unlock()
 			_ = client.Close()
 		}
 	}()
 
-	n.connMu.Lock()
-	n.sshClient = client
-	n.connMu.Unlock()
+	c.connMu.Lock()
+	c.sshClient = client
+	c.connMu.Unlock()
 
-	stdout, stdin, err := n.startSession(client)
+	stdout, stdin, err := c.startSession(client)
 	if err != nil {
 		return nil, err
 	}
 
-	n.connMu.Lock()
-	n.stdin = stdin
-	n.connMu.Unlock()
+	c.connMu.Lock()
+	c.stdin = stdin
+	c.connMu.Unlock()
 
-	n.broadcast([]byte(fmt.Sprintf("\n[Console %s connected at %s]\n",
-		n.nodeID, time.Now().Format(time.RFC3339))))
+	c.broadcast([]byte(fmt.Sprintf("\n[Console %s connected at %s]\n",
+		c.nodeID, time.Now().Format(time.RFC3339))))
 
 	success = true
 	return stdout, nil
 }
 
-// buildAuth selects the SSH auth method based on credentials and keyPath.
-// Priority matches the original ssh-pwd-console / ssh-key-console scripts:
-//   - Password set → password auth (even when a key file is also present)
-//   - No password   → key auth: cert+key if cert exists, key-only otherwise
-func (n *SSHConsoleNode) buildAuth(creds compcredentials.CompCredentials) ([]gossh.AuthMethod, error) {
-	// Password takes priority — matches ssh-pwd-console behaviour.
+// buildAuth selects authentication for a credential entry.
+// Passwords take priority. Empty passwords use the key and optional certificate.
+func (c *SSHConsole) buildAuth(creds compcredentials.CompCredentials) ([]gossh.AuthMethod, error) {
+	// Password authentication takes priority.
 	if creds.Password != "" {
 		return []gossh.AuthMethod{gossh.Password(creds.Password)}, nil
 	}
 
-	// No password: attempt key-based auth — matches ssh-key-console behaviour.
-	if n.keyPath == "" {
-		return nil, fmt.Errorf("no SSH auth available for %s: no password and no key path configured", n.nodeID)
+	// Use key authentication when the password is empty.
+	if c.keyPath == "" {
+		return nil, fmt.Errorf("no SSH auth available for %s: no password and no key path configured", c.nodeID)
 	}
 
-	keyData, err := os.ReadFile(n.keyPath)
+	keyData, err := os.ReadFile(c.keyPath)
 	if err != nil {
-		return nil, fmt.Errorf("read SSH key %s: %w", n.keyPath, err)
+		return nil, fmt.Errorf("read SSH key %s: %w", c.keyPath, err)
 	}
 	signer, err := gossh.ParsePrivateKey(keyData)
 	if err != nil {
 		return nil, fmt.Errorf("parse SSH private key: %w", err)
 	}
 
-	// Check for a certificate alongside the key.
-	certPath := n.keyPath + "-cert.pub"
+	certPath := c.keyPath + "-cert.pub"
 	certData, err := os.ReadFile(certPath)
 	if err == nil {
 		pubKey, _, _, _, err := gossh.ParseAuthorizedKey(certData)
@@ -447,75 +452,68 @@ func (n *SSHConsoleNode) buildAuth(creds compcredentials.CompCredentials) ([]gos
 		return []gossh.AuthMethod{gossh.PublicKeys(certSigner)}, nil
 	}
 
-	// Key only (no cert).
 	return []gossh.AuthMethod{gossh.PublicKeys(signer)}, nil
 }
 
-// broadcast sends data to the log file and all attached client channels.
-// Called only from the Run goroutine — no lock needed for logFile writes.
-func (n *SSHConsoleNode) broadcast(data []byte) {
-	// Handle log rotation signal (non-blocking, depth-1 channel debounces).
+// broadcast writes data to the log and attached clients.
+// Run is its only caller.
+func (c *SSHConsole) broadcast(data []byte) {
+	// Apply one pending log rotation signal.
 	select {
-	case <-n.reopenLogCh:
-		if n.logFile != nil {
-			_ = n.logFile.Close()
+	case <-c.reopenLogCh:
+		if c.logFile != nil {
+			_ = c.logFile.Close()
 		}
+		c.logFormatter.reset()
 		var err error
-		n.logFile, err = os.OpenFile(n.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
+		c.logFile, err = os.OpenFile(c.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 		if err != nil {
-			slog.Error("Failed to reopen SSH console log after rotation", "nodeID", n.nodeID, "error", err)
-			n.logFile = nil
+			slog.Error("Failed to reopen SSH console log after rotation", "nodeID", c.nodeID, "error", err)
+			c.logFile = nil
 		}
 	default:
 	}
 
-	if n.logFile != nil {
-		if _, err := n.logFile.Write(data); err != nil {
-			slog.Warn("Failed to write to SSH console log", "nodeID", n.nodeID, "error", err)
+	if c.logFile != nil {
+		logData := c.logFormatter.format(data, time.Now())
+		if _, err := c.logFile.Write(logData); err != nil {
+			slog.Warn("Failed to write to SSH console log", "nodeID", c.nodeID, "error", err)
 		}
 	}
 
-	n.clientsMu.Lock()
-	defer n.clientsMu.Unlock()
-	for id, c := range n.clients {
-		n.sendToClient(id, c, data)
+	c.clientsMu.Lock()
+	defer c.clientsMu.Unlock()
+	for id, client := range c.clients {
+		c.sendToClient(id, client, data)
 	}
 }
 
-// sendToClient delivers data to one client, accounting for anything discarded
-// because its channel was full. Must be called with clientsMu held for writing.
-//
-// A drop notice cannot be delivered at the moment of the drop — the channel is
-// full, which is the whole problem. It is held until the client has drained
-// enough to accept it, and every byte lost in the meantime is folded into the
-// same notice, so a client stalled for megabytes gets one accurate line rather
-// than a flood. The notice is emitted before the data that follows it, which
-// puts the gap marker in the right place in the client's stream.
-func (n *SSHConsoleNode) sendToClient(id string, c *consoleClient, data []byte) {
-	if c.dropped > 0 {
+// sendToClient delivers data while tracking dropped bytes.
+// Drop notices wait for capacity and precede new data.
+// Call with clientsMu held for writing.
+func (c *SSHConsole) sendToClient(id string, client *consoleClient, data []byte) {
+	if client.dropped > 0 {
 		select {
-		case c.ch <- dropNotice(n.nodeID, c.dropped):
+		case client.ch <- dropNotice(c.nodeID, client.dropped):
 			slog.Info("SSH console client caught up after dropping output",
-				"nodeID", n.nodeID, "clientID", id, "bytesDropped", c.dropped)
-			c.dropped = 0
+				"nodeID", c.nodeID, "clientID", id, "bytesDropped", client.dropped)
+			client.dropped = 0
 		default:
-			// Still backed up. Keep counting; do not try to send the data.
-			c.dropped += len(data)
+			// Keep counting while the client is backed up.
+			client.dropped += len(data)
 			return
 		}
 	}
 
 	select {
-	case c.ch <- append([]byte{}, data...):
+	case client.ch <- append([]byte{}, data...):
 	default:
-		if c.dropped == 0 {
-			// Log the transition only. Logging every dropped chunk would put
-			// one line per 32KB read into the service log for as long as the
-			// client stays behind.
+		if client.dropped == 0 {
+			// Log only when dropping begins.
 			slog.Warn("SSH console client not keeping up, dropping output",
-				"nodeID", n.nodeID, "clientID", id)
+				"nodeID", c.nodeID, "clientID", id)
 		}
-		c.dropped += len(data)
+		client.dropped += len(data)
 	}
 }
 
@@ -526,49 +524,38 @@ func dropNotice(nodeID string, bytesDropped int) []byte {
 		nodeID, bytesDropped)
 }
 
-// clientBufferDepth is how many output chunks a client may fall behind before
-// the node starts discarding its output. It matches the conman backend so both
-// consoles behave the same under a slow client.
-//
-// The unit is chunks, not bytes: one chunk is whatever a single read of the SSH
-// session returned, up to the 32KB streamStdout buffer. Depth buys a client
-// time to recover from a stall, but only up to a point — an interactive console
-// that is megabytes behind is not much use, and past there an acknowledged gap
-// beats a long lag. Raise this only with evidence from the "not keeping up"
-// warning in the service log.
+// clientBufferDepth limits queued output for each client.
+// It matches ConMan buffering. Each item is up to 32 KB.
 const clientBufferDepth = 256
 
-// Attach registers a client receive channel. Returns a buffered channel that
-// receives console output. The manager ensures the node exists before calling.
-func (n *SSHConsoleNode) Attach(clientID string) chan []byte {
+// Attach registers a buffered client channel.
+func (c *SSHConsole) Attach(clientID string) chan []byte {
 	ch := make(chan []byte, clientBufferDepth)
-	n.clientsMu.Lock()
-	n.clients[clientID] = &consoleClient{ch: ch}
-	n.clientsMu.Unlock()
+	c.clientsMu.Lock()
+	c.clients[clientID] = &consoleClient{ch: ch}
+	c.clientsMu.Unlock()
 	return ch
 }
 
 // Detach deregisters a client channel. Idempotent.
-func (n *SSHConsoleNode) Detach(clientID string) {
-	n.clientsMu.Lock()
-	defer n.clientsMu.Unlock()
-	if c, ok := n.clients[clientID]; ok {
-		close(c.ch)
-		delete(n.clients, clientID)
+func (c *SSHConsole) Detach(clientID string) {
+	c.clientsMu.Lock()
+	defer c.clientsMu.Unlock()
+	if client, ok := c.clients[clientID]; ok {
+		close(client.ch)
+		delete(c.clients, clientID)
 	}
 }
 
-// Write sends data to the SSH session's stdin. It reports ErrNotConnected
-// rather than claiming a successful write when the node is between
-// connections, so callers can decide what to do with the discarded input; a
-// transient disconnect is not a reason to tear the caller down.
-func (n *SSHConsoleNode) Write(p []byte) (int, error) {
-	n.stdinMu.Lock()
-	defer n.stdinMu.Unlock()
+// Write sends data to the SSH session.
+// ErrNotConnected means no input was written during a reconnect.
+func (c *SSHConsole) Write(p []byte) (int, error) {
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
 
-	n.connMu.Lock()
-	stdin := n.stdin
-	n.connMu.Unlock()
+	c.connMu.Lock()
+	stdin := c.stdin
+	c.connMu.Unlock()
 
 	if stdin == nil {
 		return 0, ErrNotConnected
@@ -578,24 +565,31 @@ func (n *SSHConsoleNode) Write(p []byte) (int, error) {
 
 // UpdateCreds updates stored credentials and forces a reconnect so the new
 // credentials take effect.
-func (n *SSHConsoleNode) UpdateCreds(creds compcredentials.CompCredentials) {
-	n.credsMu.Lock()
-	n.creds = creds
-	n.credsMu.Unlock()
+func (c *SSHConsole) UpdateCreds(creds compcredentials.CompCredentials) {
+	c.credsMu.Lock()
+	c.creds = &creds
+	c.credsMu.Unlock()
+
+	// Wake Run when the first credentials arrive.
+	// A buffered signal avoids missed wakeups.
+	select {
+	case c.credsCh <- struct{}{}:
+	default:
+	}
 
 	// Close the current connection to trigger reconnect with new creds.
-	n.connMu.Lock()
-	client := n.sshClient
-	n.connMu.Unlock()
+	c.connMu.Lock()
+	client := c.sshClient
+	c.connMu.Unlock()
 	if client != nil {
 		_ = client.Close()
 	}
 }
 
 // ReopenLog signals the Run goroutine to reopen the log file (after rotation).
-func (n *SSHConsoleNode) ReopenLog() {
+func (c *SSHConsole) ReopenLog() {
 	select {
-	case n.reopenLogCh <- struct{}{}:
-	default: // already signalled; no-op
+	case c.reopenLogCh <- struct{}{}:
+	default: // already signalled
 	}
 }

--- a/internal/ssh/console_test.go
+++ b/internal/ssh/console_test.go
@@ -12,20 +12,13 @@ import (
 	"testing"
 	"time"
 
-	compcredentials "github.com/Cray-HPE/hms-compcredentials"
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
 )
 
-// ---------------------------------------------------------------------------
-// 1. Reconnect on disconnect
-// ---------------------------------------------------------------------------
-
-// TestSSHConsoleNodeReconnect verifies that when the server drops a connection
-// the node broadcasts a disconnect marker, then reconnects automatically and
-// broadcasts a connected marker.
-func TestSSHConsoleNodeReconnect(t *testing.T) {
+// TestSSHConsoleReconnect verifies automatic reconnection and status markers.
+func TestSSHConsoleReconnect(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
 	id, nodeMap, passwords := singleNode(t, srv.addr())
@@ -34,9 +27,7 @@ func TestSSHConsoleNodeReconnect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
-		t.Fatal(err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
 	// Attach before the first connect so we capture the initial connected marker.
 	clientCh, err := manager.Attach(id, "reconnect-client")
@@ -48,25 +39,16 @@ func TestSSHConsoleNodeReconnect(t *testing.T) {
 	sess := <-sessionCh
 	waitForMarker(t, clientCh, fmt.Sprintf("[Console %s connected at", id), 15*time.Second)
 
-	// Drop the connection server-side.
 	sess.drop()
 
-	// Node should broadcast a disconnect marker.
 	waitForMarker(t, clientCh, fmt.Sprintf("[Console %s disconnected at", id), 15*time.Second)
 
-	// Server accepts the reconnect; node should broadcast another connected marker.
 	<-sessionCh
 	waitForMarker(t, clientCh, fmt.Sprintf("[Console %s connected at", id), 15*time.Second)
 }
 
-// ---------------------------------------------------------------------------
-// 2. Fan-out broadcast to multiple clients
-// ---------------------------------------------------------------------------
-
-// TestSSHConsoleNodeFanOut verifies that output from the SSH session is
-// delivered to every attached client and that a slow client (full buffer)
-// only loses its own data — it does not block other clients.
-func TestSSHConsoleNodeFanOut(t *testing.T) {
+// TestSSHConsoleFanOut verifies output reaches all clients independently.
+func TestSSHConsoleFanOut(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
 	id, nodeMap, passwords := singleNode(t, srv.addr())
@@ -75,9 +57,7 @@ func TestSSHConsoleNodeFanOut(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
-		t.Fatal(err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
 	const numClients = 5
 	clients := make([]<-chan []byte, numClients)
@@ -97,15 +77,13 @@ func TestSSHConsoleNodeFanOut(t *testing.T) {
 		waitForMarker(t, ch, fmt.Sprintf("[Console %s connected at", id), 15*time.Second)
 	}
 
-	// Server sends a known payload; every client must receive it.
 	sess.send <- []byte("broadcast-test-payload\r\n")
 	for i, ch := range clients {
 		waitForMarker(t, ch, "broadcast-test-payload", 5*time.Second)
 		t.Logf("client %d received payload", i)
 	}
 
-	// Slow-client test: fill one client's buffer so it is full, then verify
-	// the fast client still receives new data unimpeded.
+	// A full client buffer must not block another client.
 	slowCh, err := manager.Attach(id, "slow-client")
 	if err != nil {
 		t.Fatal(err)
@@ -122,21 +100,15 @@ func TestSSHConsoleNodeFanOut(t *testing.T) {
 	for i := 0; i < 64; i++ {
 		sess.send <- filler
 	}
-	time.Sleep(200 * time.Millisecond) // let broadcast goroutine saturate the slow client
+	time.Sleep(200 * time.Millisecond) // allow the slow client buffer to fill
 
 	sess.send <- []byte("after-slow-client-fill\r\n")
 	waitForMarker(t, fastCh, "after-slow-client-fill", 5*time.Second)
-	_ = slowCh // slow client may have dropped data — expected behaviour
+	_ = slowCh // slow client may have dropped data
 }
 
-// ---------------------------------------------------------------------------
-// 3. Data flow: output reaches clients, input reaches server
-// ---------------------------------------------------------------------------
-
-// TestSSHConsoleNodeDataFlow verifies that bytes written by the server arrive
-// in the client channel (output path) and bytes written by the client arrive
-// at the server's stdin (input path).
-func TestSSHConsoleNodeDataFlow(t *testing.T) {
+// TestSSHConsoleDataFlow verifies input and output forwarding.
+func TestSSHConsoleDataFlow(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
 	id, nodeMap, passwords := singleNode(t, srv.addr())
@@ -145,9 +117,7 @@ func TestSSHConsoleNodeDataFlow(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
-		t.Fatal(err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
 	clientCh, err := manager.Attach(id, "data-client")
 	if err != nil {
@@ -158,11 +128,9 @@ func TestSSHConsoleNodeDataFlow(t *testing.T) {
 	sess := <-sessionCh
 	waitForMarker(t, clientCh, fmt.Sprintf("[Console %s connected at", id), 15*time.Second)
 
-	// Output path: server → client.
 	sess.send <- []byte("hello-from-server\r\n")
 	waitForMarker(t, clientCh, "hello-from-server", 5*time.Second)
 
-	// Input path: client → server.
 	if _, err := manager.Write(id, []byte("hello-from-client\r\n")); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
@@ -184,14 +152,8 @@ func TestSSHConsoleNodeDataFlow(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// 4. Node lifecycle via UpdateNodesAndCredentials
-// ---------------------------------------------------------------------------
-
-// TestSSHConsoleNodeLifecycle verifies that removing a node via
-// UpdateNodesAndCredentials cancels its Run goroutine and that all associated
-// goroutines exit cleanly.
-func TestSSHConsoleNodeLifecycle(t *testing.T) {
+// TestSSHConsoleLifecycle verifies node removal stops its goroutines.
+func TestSSHConsoleLifecycle(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
 	id, nodeMap, passwords := singleNode(t, srv.addr())
@@ -202,21 +164,16 @@ func TestSSHConsoleNodeLifecycle(t *testing.T) {
 
 	goroutinesBefore := runtime.NumGoroutine()
 
-	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
-		t.Fatal(err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
-	// Wait for the node to connect.
 	<-sessionCh
 	t.Logf("goroutines with node: %d (added %d)", runtime.NumGoroutine(), runtime.NumGoroutine()-goroutinesBefore)
 
-	// Remove the node. The manager is the sole authority on node lifetime, so
-	// cancelling through UpdateNodesAndCredentials must be enough to stop Run.
-	if err := manager.UpdateNodesAndCredentials(ctx, map[string]*nodes.NodeConsoleInfo{}, map[string]compcredentials.CompCredentials{}); err != nil {
+	// Removing the node must stop Run.
+	if err := manager.UpdateNodes(ctx, map[string]*nodes.NodeConsoleInfo{}); err != nil {
 		t.Fatal(err)
 	}
 
-	// Attach should now fail.
 	if _, err := manager.Attach(id, "post-remove"); err == nil {
 		t.Error("Attach succeeded after node removal")
 	}
@@ -236,16 +193,7 @@ func TestSSHConsoleNodeLifecycle(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// 6. Slow client accounting
-// ---------------------------------------------------------------------------
-
-// TestSlowClientGetsDropNotice covers the case where a client cannot keep up
-// with console output. The node has to discard the overflow — it will not stall
-// every other client and the log file to wait for one slow websocket — but
-// discarding it silently hands the operator a console stream with an
-// unmarked hole in it. The dropped bytes must be accounted for in the client's
-// own stream once it drains enough to receive the notice.
+// TestSlowClientGetsDropNotice verifies dropped output is reported in place.
 func TestSlowClientGetsDropNotice(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
@@ -255,9 +203,7 @@ func TestSlowClientGetsDropNotice(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
-		t.Fatal(err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
 	clientCh, err := manager.Attach(id, "slow-client")
 	if err != nil {
@@ -268,17 +214,8 @@ func TestSlowClientGetsDropNotice(t *testing.T) {
 	sess := <-sessionCh
 	waitForMarker(t, clientCh, fmt.Sprintf("[Console %s connected at", id), 15*time.Second)
 
-	// Flood the node while reading nothing. The server's writes are
-	// flow-controlled by the SSH window, which only advances as the node reads,
-	// so once every send has been accepted the node has consumed the lot — and
-	// with the client reading none of it, everything past the channel's depth
-	// must have been dropped.
-	//
-	// The burst has to beat that depth measured in broadcasts, not bytes.
-	// streamStdout reads up to 32KB at a time, so the worst case for this test
-	// is the sends coalescing into 32KB chunks: 24MB still yields ~750
-	// broadcasts against a channel that holds clientBufferDepth (256). Keep the
-	// margin if that constant grows.
+	// Send enough data to overflow the client buffer even with 32 KB reads.
+	// The SSH window confirms accepted data was consumed by the console.
 	const (
 		bursts    = 1500
 		chunkSize = 16 * 1024
@@ -295,10 +232,7 @@ func TestSlowClientGetsDropNotice(t *testing.T) {
 		}
 	}
 
-	// Drain what the client did manage to buffer, keeping everything it saw.
-	// The notice may land here — as soon as the channel has room, the next
-	// broadcast carries it — or on the resume write below, so the assertions
-	// have to look at the whole stream rather than at one read.
+	// The notice may arrive while draining or after output resumes.
 	var seen strings.Builder
 	drained := 0
 drain:
@@ -337,8 +271,7 @@ drain:
 	if !strings.Contains(seen.String()[at:], "bytes of output dropped") {
 		t.Errorf("drop notice is not the expected marker: %q", seen.String()[at:min(at+120, seen.Len())])
 	}
-	// The notice has to sit at the gap. Behind the resumed output it would tell
-	// the operator the wrong thing about where the console skipped.
+	// The notice must precede resumed output.
 	if at > strings.Index(seen.String(), "back-in-sync") {
 		t.Error("drop notice arrived after the resumed output; it marks the wrong point in the stream")
 	}

--- a/internal/ssh/log.go
+++ b/internal/ssh/log.go
@@ -1,0 +1,111 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package ssh
+
+import "time"
+
+const consoleLogTimestampFormat = "2006-01-02 15:04:05 "
+
+// consoleLogLineState tracks line boundaries that may span SSH reads.
+type consoleLogLineState uint8
+
+const (
+	consoleLogLineInit consoleLogLineState = iota // No line data has been written.
+	consoleLogLineData                            // The current line contains data.
+	consoleLogLineCR                              // A carriage return may be followed by a line feed.
+	consoleLogLineLF                              // The previous line ended.
+)
+
+// consoleLogFormatter matches ConMan line timestamps and sanitization.
+type consoleLogFormatter struct {
+	state consoleLogLineState
+}
+
+func newConsoleLogFormatter() consoleLogFormatter {
+	return consoleLogFormatter{}
+}
+
+func (f *consoleLogFormatter) reset() {
+	f.state = consoleLogLineInit
+}
+
+func (f *consoleLogFormatter) format(data []byte, now time.Time) []byte {
+	if len(data) == 0 {
+		return nil
+	}
+
+	timestamp := now.Format(consoleLogTimestampFormat)
+	formatted := make([]byte, 0, len(data)+len(timestamp))
+
+	// Preserve line state because SSH reads may split a line ending.
+	for _, b := range data {
+		switch b {
+		case '\r':
+			// Hold a carriage return until the next byte identifies the line ending.
+			switch f.state {
+			case consoleLogLineData:
+				f.state = consoleLogLineCR
+			case consoleLogLineInit:
+				formatted = append(formatted, timestamp...)
+				f.state = consoleLogLineCR
+			}
+
+		case '\n':
+			// Normalize line endings and mark the next byte as a new line.
+			if f.state == consoleLogLineInit || f.state == consoleLogLineLF {
+				formatted = append(formatted, timestamp...)
+			}
+			formatted = append(formatted, '\r', '\n')
+			f.state = consoleLogLineLF
+
+		case 0:
+			// ConMan ignores a NUL immediately after a line ending.
+			if f.state == consoleLogLineCR || f.state == consoleLogLineLF {
+				continue
+			}
+			formatted = f.appendByte(formatted, b, timestamp)
+
+		default:
+			formatted = f.appendByte(formatted, b, timestamp)
+		}
+	}
+
+	return formatted
+}
+
+func (f *consoleLogFormatter) appendByte(dst []byte, b byte, timestamp string) []byte {
+	// Complete a lone carriage return as a normalized line ending.
+	if f.state == consoleLogLineCR {
+		dst = append(dst, '\r', '\n')
+	}
+
+	// Timestamp only the first byte of each logical line.
+	if f.state != consoleLogLineData {
+		dst = append(dst, timestamp...)
+	}
+	f.state = consoleLogLineData
+
+	// Match ConMan caret and meta notation, which differs from strconv quoting.
+	c := b & 0x7f
+	switch {
+	case c < 0x20:
+		prefix := byte('^')
+		if b&0x80 != 0 {
+			prefix = '~'
+		}
+		return append(dst, prefix, c+'@')
+	case c == 0x7f:
+		prefix := byte('^')
+		if b&0x80 != 0 {
+			prefix = '~'
+		}
+		return append(dst, prefix, '?')
+	default:
+		if b&0x80 != 0 {
+			dst = append(dst, '`')
+		}
+		return append(dst, c)
+	}
+}

--- a/internal/ssh/log_test.go
+++ b/internal/ssh/log_test.go
@@ -1,0 +1,98 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package ssh
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+)
+
+func TestConsoleLogFormatter(t *testing.T) {
+	now := time.Date(2026, time.July, 31, 12, 34, 56, 0, time.UTC)
+	timestamp := "2026-07-31 12:34:56 "
+
+	tests := []struct {
+		name  string
+		input []byte
+		want  []byte
+	}{
+		{
+			name:  "timestamps lines",
+			input: []byte("first\r\nsecond\n"),
+			want:  []byte(timestamp + "first\r\n" + timestamp + "second\r\n"),
+		},
+		{
+			name:  "sanitizes controls",
+			input: []byte{'a', '\t', 0x1b, 0x7f, 0x80, 0xff, '\n'},
+			want:  []byte(timestamp + "a^I^[^?~@~?\r\n"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatter := newConsoleLogFormatter()
+			if got := formatter.format(tt.input, now); !bytes.Equal(got, tt.want) {
+				t.Fatalf("format() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConsoleLogFormatterMaintainsLineState(t *testing.T) {
+	now := time.Date(2026, time.July, 31, 12, 34, 56, 0, time.UTC)
+	timestamp := "2026-07-31 12:34:56 "
+	formatter := newConsoleLogFormatter()
+
+	var got []byte
+	got = append(got, formatter.format([]byte("part"), now)...)
+	got = append(got, formatter.format([]byte("ial\r"), now)...)
+	got = append(got, formatter.format([]byte("\nnext\n"), now)...)
+
+	want := []byte(timestamp + "partial\r\n" + timestamp + "next\r\n")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("split format() = %q, want %q", got, want)
+	}
+}
+
+func TestBroadcastFormatsOnlyLogOutput(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "console.node")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := logFile.Close(); err != nil {
+			t.Errorf("close log file: %v", err)
+		}
+	})
+
+	clientCh := make(chan []byte, 1)
+	console := &SSHConsole{
+		clients: map[string]*consoleClient{
+			"client": {ch: clientCh},
+		},
+		logFile:      logFile,
+		reopenLogCh:  make(chan struct{}, 1),
+		logFormatter: newConsoleLogFormatter(),
+	}
+	input := []byte("\x1b[31mred\r\n")
+	console.broadcast(input)
+
+	if got := <-clientCh; !bytes.Equal(got, input) {
+		t.Fatalf("client output = %q, want raw output %q", got, input)
+	}
+	logged, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \^\[\[31mred\r\n$`)
+	if !want.Match(logged) {
+		t.Fatalf("log output = %q, want a timestamped and sanitized line", logged)
+	}
+}

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -24,22 +24,23 @@ import (
 // whereas this clears on its own once the node reconnects.
 var ErrNotConnected = errors.New("ssh console node not connected")
 
-// SSHConsoleManager manages the set of active SSHConsoleNodes.
+// SSHConsoleManager manages the set of active SSHConsoles, one per SSH node in
+// the cluster inventory and keyed by node ID.
 type SSHConsoleManager struct {
 	cfg      SSHConfig
 	keyPath  string
 	logsPath string // e.g. /var/log/conman/conman
 
-	// nodesMu protects the nodes map.
-	// Lock ordering: nodesMu → clientsMu, nodesMu → connMu
-	nodesMu sync.RWMutex
-	nodes   map[string]*SSHConsoleNode
-	// cancels maps nodeID to the cancel func for that node's Run goroutine.
+	// consolesMu protects the consoles map.
+	// Lock ordering: consolesMu → clientsMu, consolesMu → connMu
+	consolesMu sync.RWMutex
+	consoles   map[string]*SSHConsole
+	// cancels maps nodeID to the cancel func for that console's Run goroutine.
 	cancels map[string]context.CancelFunc
 
 	// running tracks the live Run goroutines so callers can tell when the last
-	// one has released its log file. Cancelling a node's context only asks it
-	// to stop; the goroutine may still be opening or writing its log for a
+	// one has released its log file. Cancelling a console's context only asks
+	// it to stop; the goroutine may still be opening or writing its log for a
 	// short while afterwards. See Wait.
 	running sync.WaitGroup
 }
@@ -54,7 +55,7 @@ func NewSSHConsoleManager(cfg SSHConfig, keyPath, logsPath string) *SSHConsoleMa
 		cfg:      cfg,
 		keyPath:  keyPath,
 		logsPath: logsPath,
-		nodes:    make(map[string]*SSHConsoleNode),
+		consoles: make(map[string]*SSHConsole),
 		cancels:  make(map[string]context.CancelFunc),
 	}
 }
@@ -81,110 +82,67 @@ func credsChanged(a, b compcredentials.CompCredentials) bool {
 // connection parameters changed are restarted. Every node that survives the
 // diff keeps the credentials it is already using.
 //
-// ctx must be the long-lived service context — node goroutines run until it is
-// cancelled or the node is explicitly stopped.
+// ctx must be the long-lived service context — console goroutines run until it
+// is cancelled or the node leaves inventory.
 //
-// This is the operation for a caller that could not obtain a complete set of
-// credentials, because an absent entry in a passwords map is ambiguous: it
-// means "use key auth" for a node with no Vault entry, but it also means
-// "Vault did not answer for this node this time", since
-// GetPasswordsWithRetries returns a partial map with a nil error once it
-// exhausts its retries. Leaving auth alone keeps working nodes working while
-// the membership change still takes effect.
+// Membership is the only thing this decides; authentication belongs to
+// UpdateCredentials. A node change reports which nodes exist, and that says
+// nothing about credentials, so nothing here needs a credential fetch to
+// succeed — or to have happened at all.
 //
-// Nodes discovered here start with no password and therefore attempt key auth.
-// If they are really password nodes they will fail and back off until a later
-// successful fetch reaches them through UpdateCredentials.
+// A node discovered here starts with no credentials. It registers and accepts
+// Attach, but does not connect until UpdateCredentials brings it a Vault entry;
+// see NodesAwaitingCredentials.
 func (m *SSHConsoleManager) UpdateNodes(
 	ctx context.Context,
 	sshNodes map[string]*nodes.NodeConsoleInfo,
 ) error {
-	return m.update(ctx, sshNodes, nil, false)
-}
+	m.consolesMu.Lock()
+	defer m.consolesMu.Unlock()
 
-// UpdateNodesAndCredentials does everything UpdateNodes does, and additionally
-// applies passwords: a node whose credentials changed gets UpdateCreds called,
-// which reconnects it under the new ones.
-//
-// passwords is taken as authoritative — a nodeID absent from it means that node
-// has no stored password and should authenticate with the configured SSH key
-// (see buildAuth). Only call this when the credential fetch succeeded. A
-// partial map from a failed fetch would strip working password nodes down to
-// key auth; use UpdateNodes for that case.
-func (m *SSHConsoleManager) UpdateNodesAndCredentials(
-	ctx context.Context,
-	sshNodes map[string]*nodes.NodeConsoleInfo,
-	passwords map[string]compcredentials.CompCredentials,
-) error {
-	return m.update(ctx, sshNodes, passwords, true)
-}
-
-// update is the shared implementation. When applyCreds is false, passwords is
-// ignored for nodes that already exist and their current credentials are kept.
-func (m *SSHConsoleManager) update(
-	ctx context.Context,
-	sshNodes map[string]*nodes.NodeConsoleInfo,
-	passwords map[string]compcredentials.CompCredentials,
-	applyCreds bool,
-) error {
-	m.nodesMu.Lock()
-	defer m.nodesMu.Unlock()
-
-	// Stop nodes that are no longer in the updated set.
+	// Stop the consoles of nodes that are no longer in the updated set.
 	for nodeID, cancel := range m.cancels {
 		if _, stillActive := sshNodes[nodeID]; !stillActive {
-			slog.Info("Stopping SSH console node", "nodeID", nodeID)
+			slog.Info("Stopping SSH console", "nodeID", nodeID)
 			cancel()
-			delete(m.nodes, nodeID)
+			delete(m.consoles, nodeID)
 			delete(m.cancels, nodeID)
 		}
 	}
 
 	for nodeID, info := range sshNodes {
-		// An absent entry is an empty password, which buildAuth resolves to key
-		// auth. That is only a safe reading when the caller vouched for the map.
-		creds := passwords[nodeID]
-
-		existing, exists := m.nodes[nodeID]
+		existing, exists := m.consoles[nodeID]
 		if !exists {
-			m.startNode(ctx, nodeID, info, creds)
+			// nil credentials: the console parks until UpdateCredentials reaches it.
+			m.startConsole(ctx, nodeID, info, nil)
 			continue
 		}
 
 		if nodeChanged(existing.info, info) {
-			// Connection parameters changed — restart. Keep the credentials the
-			// node already has when this update is not allowed to set them.
+			// Connection parameters changed — replace the console, carrying the
+			// credentials the old one was using.
 			slog.Info("SSH console node parameters changed, restarting", "nodeID", nodeID)
-			if !applyCreds {
-				creds = existing.currentCreds()
-			}
+			creds := existing.currentCreds()
 			m.cancels[nodeID]()
-			m.startNode(ctx, nodeID, info, creds)
-			continue
-		}
-
-		if applyCreds && credsChanged(existing.currentCreds(), creds) {
-			// Credentials only — reconnect in place without full restart.
-			slog.Info("SSH console node credentials changed, reconnecting", "nodeID", nodeID)
-			existing.UpdateCreds(creds)
+			m.startConsole(ctx, nodeID, info, creds)
 		}
 	}
 
 	return nil
 }
 
-// startNode creates and starts a new SSHConsoleNode. Must be called with nodesMu held.
-func (m *SSHConsoleManager) startNode(ctx context.Context, nodeID string, info *nodes.NodeConsoleInfo, creds compcredentials.CompCredentials) {
-	nodeCtx, nodeCancel := context.WithCancel(ctx)
-	node := newSSHConsoleNode(nodeID, info, creds, m.keyPath, m.logPath(nodeID), m.cfg)
-	node.cancel = nodeCancel
-	m.nodes[nodeID] = node
-	m.cancels[nodeID] = nodeCancel
-	slog.Info("Starting SSH console node", "nodeID", nodeID, "host", info.ConnectionHost)
+// startConsole creates and starts the console for one node. Must be called with
+// consolesMu held. A nil creds means none have been fetched for this node yet.
+func (m *SSHConsoleManager) startConsole(ctx context.Context, nodeID string, info *nodes.NodeConsoleInfo, creds *compcredentials.CompCredentials) {
+	consoleCtx, consoleCancel := context.WithCancel(ctx)
+	console := newSSHConsole(nodeID, info, creds, m.keyPath, m.logPath(nodeID), m.cfg, consoleCancel)
+	m.consoles[nodeID] = console
+	m.cancels[nodeID] = consoleCancel
+	slog.Info("Starting SSH console", "nodeID", nodeID, "host", info.ConnectionHost)
 	m.running.Add(1)
 	go func() {
 		defer m.running.Done()
-		node.Run(nodeCtx)
+		console.Run(consoleCtx)
 	}()
 }
 
@@ -194,57 +152,88 @@ func (m *SSHConsoleManager) Wait() {
 	m.running.Wait()
 }
 
-// UpdateCredentials updates credentials for nodes whose passwords have changed.
-// Nodes that changed connection info should use UpdateNodesAndCredentials instead.
+// UpdateCredentials delivers Vault entries to managed nodes, reconnecting any
+// node whose entry differs from the one it is using. It is the only way
+// credentials enter the manager; UpdateNodes never touches them.
+//
+// Only node IDs present in passwords are considered. An absent node is left
+// alone rather than cleared: a credential that has not arrived is not evidence
+// that a node has none, and a fetch can come back short for reasons that have
+// nothing to do with the node. A caller may therefore pass whatever it managed
+// to fetch without first deciding whether the result is complete.
+//
+// Moving a node from password to key auth is done by clearing the password on
+// its Vault entry, not by deleting the entry — the username is still needed
+// either way. That arrives here as a changed entry and is applied normally.
 func (m *SSHConsoleManager) UpdateCredentials(passwords map[string]compcredentials.CompCredentials) {
-	m.nodesMu.RLock()
+	m.consolesMu.RLock()
 	type pending struct {
-		node  *SSHConsoleNode
-		creds compcredentials.CompCredentials
+		console *SSHConsole
+		creds   compcredentials.CompCredentials
 	}
 	var updates []pending
-	for nodeID, node := range m.nodes {
+	for nodeID, console := range m.consoles {
 		if creds, ok := passwords[nodeID]; ok {
-			if credsChanged(node.currentCreds(), creds) {
-				updates = append(updates, pending{node, creds})
+			// A node still waiting for its first entry always counts as changed.
+			if current := console.currentCreds(); current == nil || credsChanged(*current, creds) {
+				updates = append(updates, pending{console, creds})
 			}
 		}
 	}
-	m.nodesMu.RUnlock()
+	m.consolesMu.RUnlock()
 
 	for _, u := range updates {
-		u.node.UpdateCreds(u.creds)
+		u.console.UpdateCreds(u.creds)
 	}
 }
 
-// ReopenLogs signals all active nodes to reopen their log files after rotation.
+// NodesAwaitingCredentials returns the IDs of managed nodes that have not yet
+// received a Vault entry. Those nodes are registered but parked — they will not
+// connect until UpdateCredentials reaches them.
+//
+// The credential watcher uses this to decide it has work to do. Watching Vault
+// for changes is not enough on its own: a node added after startup needs its
+// entry fetched even though nothing in Vault changed.
+func (m *SSHConsoleManager) NodesAwaitingCredentials() []string {
+	m.consolesMu.RLock()
+	defer m.consolesMu.RUnlock()
+	var waiting []string
+	for nodeID, console := range m.consoles {
+		if console.currentCreds() == nil {
+			waiting = append(waiting, nodeID)
+		}
+	}
+	return waiting
+}
+
+// ReopenLogs signals all active consoles to reopen their log files after rotation.
 func (m *SSHConsoleManager) ReopenLogs() {
-	m.nodesMu.RLock()
-	defer m.nodesMu.RUnlock()
-	for _, node := range m.nodes {
-		node.ReopenLog()
+	m.consolesMu.RLock()
+	defer m.consolesMu.RUnlock()
+	for _, console := range m.consoles {
+		console.ReopenLog()
 	}
 }
 
 // Attach connects an interactive client to an SSH console node.
 // Returns an error if the node is not managed by this manager.
 func (m *SSHConsoleManager) Attach(nodeID, clientID string) (chan []byte, error) {
-	m.nodesMu.RLock()
-	node, ok := m.nodes[nodeID]
-	m.nodesMu.RUnlock()
+	m.consolesMu.RLock()
+	console, ok := m.consoles[nodeID]
+	m.consolesMu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("SSH console node %q not found", nodeID)
 	}
-	return node.Attach(clientID), nil
+	return console.Attach(clientID), nil
 }
 
 // Detach disconnects a client from an SSH console node. No-op if not found.
 func (m *SSHConsoleManager) Detach(nodeID, clientID string) {
-	m.nodesMu.RLock()
-	node, ok := m.nodes[nodeID]
-	m.nodesMu.RUnlock()
+	m.consolesMu.RLock()
+	console, ok := m.consoles[nodeID]
+	m.consolesMu.RUnlock()
 	if ok {
-		node.Detach(clientID)
+		console.Detach(clientID)
 	}
 }
 
@@ -252,11 +241,11 @@ func (m *SSHConsoleManager) Detach(nodeID, clientID string) {
 // the node is not managed by this manager, and ErrNotConnected if it is managed
 // but currently disconnected.
 func (m *SSHConsoleManager) Write(nodeID string, p []byte) (int, error) {
-	m.nodesMu.RLock()
-	node, ok := m.nodes[nodeID]
-	m.nodesMu.RUnlock()
+	m.consolesMu.RLock()
+	console, ok := m.consoles[nodeID]
+	m.consolesMu.RUnlock()
 	if !ok {
 		return 0, fmt.Errorf("SSH console node %q not found", nodeID)
 	}
-	return node.Write(p)
+	return console.Write(p)
 }

--- a/internal/ssh/manager_test.go
+++ b/internal/ssh/manager_test.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -47,9 +49,7 @@ func TestWriteWhileDisconnectedReportsNotConnected(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
-		t.Fatal(err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
 	n, err := manager.Write(id, []byte("into the void\n"))
 	if !errors.Is(err, ssh.ErrNotConnected) {
@@ -86,12 +86,11 @@ func waitForBytes(t *testing.T, sess *sshSession, want string, timeout time.Dura
 	}
 }
 
-// TestUpdateNodesPreservesCredentials covers the case where the service's
-// credential fetch failed and it falls back to a credential-preserving
-// update. A
-// healthy node must keep running on the credentials it already has. Applying
-// the empty password would trigger UpdateCreds, drop the connection, and then
-// fall through to key auth, which is not what this node uses.
+// TestUpdateNodesPreservesCredentials pins the split between the two update
+// operations. UpdateNodes decides membership and nothing else; a healthy node
+// that survives the diff must keep running on the credentials it already has.
+// Clearing them would trigger UpdateCreds, drop the connection, and fall
+// through to key auth, which is not what this node uses.
 func TestUpdateNodesPreservesCredentials(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
@@ -101,9 +100,7 @@ func TestUpdateNodesPreservesCredentials(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
-		t.Fatal(err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
 	// Attach before the first connect completes. node.Write silently drops and
 	// reports success while stdin is nil, so writing before the node is fully
@@ -123,8 +120,7 @@ func TestUpdateNodesPreservesCredentials(t *testing.T) {
 	}
 	waitForBytes(t, sess, "before", 15*time.Second)
 
-	// Same node set, credentials incomplete — what the service does when the
-	// fetch fails.
+	// Same node set — the node survives the diff untouched.
 	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
 		t.Fatal(err)
 	}
@@ -133,7 +129,7 @@ func TestUpdateNodesPreservesCredentials(t *testing.T) {
 	// cleared, UpdateCreds would have torn this connection down.
 	select {
 	case <-sessionCh:
-		t.Fatal("node reconnected after a credential-preserving update; existing credentials were not preserved")
+		t.Fatal("node reconnected after a membership-only update; UpdateNodes touched its credentials")
 	case <-time.After(2 * time.Second):
 	}
 
@@ -143,10 +139,10 @@ func TestUpdateNodesPreservesCredentials(t *testing.T) {
 	waitForBytes(t, sess, "after", 15*time.Second)
 }
 
-// TestUpdateNodesAddsAndRemovesNodes verifies that a credential-preserving update
-// still adds and removes nodes. Before this, a failed credential fetch skipped
-// the SSH update entirely, so a node removed from inventory kept its console
-// running and a newly added node never started.
+// TestUpdateNodesAddsAndRemovesNodes verifies that UpdateNodes adds and removes
+// nodes on its own, with no credentials in sight. Before the split, a failed
+// credential fetch skipped the SSH update entirely, so a node removed from
+// inventory kept its console running and a newly added node never started.
 func TestUpdateNodesAddsAndRemovesNodes(t *testing.T) {
 	srv := newSSHServer(t, func(ch gossh.Channel) { _ = ch.Close() })
 	id, nodeMap, _ := singleNode(t, srv.addr())
@@ -160,7 +156,7 @@ func TestUpdateNodesAddsAndRemovesNodes(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := manager.Attach(id, "probe"); err != nil {
-		t.Fatalf("node was not registered by a credential-preserving update: %v", err)
+		t.Fatalf("node was not registered by UpdateNodes: %v", err)
 	}
 	manager.Detach(id, "probe")
 
@@ -169,16 +165,18 @@ func TestUpdateNodesAddsAndRemovesNodes(t *testing.T) {
 		t.Fatal(err)
 	}
 	if _, err := manager.Attach(id, "probe"); err == nil {
-		t.Fatal("node still registered after removal via a credential-less update")
+		t.Fatal("node still registered after UpdateNodes dropped it")
 	}
 }
 
-// TestUpdateNodesAndCredentialsAbsentPassword pins the other half of the
-// contract. When the caller vouches for the passwords map, a nodeID absent from
-// it means the node has no stored password and should fall through to key auth
-// (buildAuth). UpdateNodesAndCredentials must therefore apply the empty credentials and
-// reconnect, rather than assuming the entry was merely missing.
-func TestUpdateNodesAndCredentialsAbsentPassword(t *testing.T) {
+// TestUpdateCredentialsIgnoresAbsentNodes pins the property that lets callers
+// pass a credential map they cannot vouch for. GetPasswordsWithRetries returns
+// whatever it managed to fetch with a nil error once it exhausts its retries,
+// so an absent nodeID says nothing about the node — only that this fetch did
+// not bring it back. UpdateCredentials must therefore leave absent nodes alone:
+// treating absence as a change would tear down a working console every time the
+// credential store had a bad minute.
+func TestUpdateCredentialsIgnoresAbsentNodes(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
 	id, nodeMap, passwords := singleNode(t, srv.addr())
@@ -187,26 +185,142 @@ func TestUpdateNodesAndCredentialsAbsentPassword(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
-		t.Fatal(err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
-	clientCh, err := manager.Attach(id, "keyauth-client")
+	clientCh, err := manager.Attach(id, "absent-client")
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer manager.Detach(id, "keyauth-client")
+	defer manager.Detach(id, "absent-client")
 
-	<-sessionCh
+	sess := <-sessionCh
 	waitForMarker(t, clientCh, "[Console "+id+" connected at", 15*time.Second)
 
-	// Authoritative update that no longer carries a password for this node.
-	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, map[string]compcredentials.CompCredentials{}); err != nil {
+	// An empty map — every node absent. Nothing may happen to this connection.
+	manager.UpdateCredentials(map[string]compcredentials.CompCredentials{})
+
+	select {
+	case <-sessionCh:
+		t.Fatal("node reconnected after an update that did not mention it; absence was read as a credential change")
+	case <-time.After(2 * time.Second):
+	}
+
+	// Still the same live session, not a silently re-established one.
+	if _, err := manager.Write(id, []byte("still-here\n")); err != nil {
+		t.Fatalf("write after the empty credential update: %v", err)
+	}
+	waitForBytes(t, sess, "still-here", 15*time.Second)
+}
+
+// waitForLogMarker polls a node's console log file until it contains marker.
+//
+// Markers are broadcast to the log as well as to attached clients, which is
+// what makes this usable where an Attach would race: a node that says something
+// once, before any client could have attached, still leaves it on disk.
+func waitForLogMarker(t *testing.T, logsDir, nodeID, marker string, timeout time.Duration) {
+	t.Helper()
+	path := filepath.Join(logsDir, "console."+nodeID)
+	deadline := time.Now().Add(timeout)
+	var last []byte
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			last = data
+			if strings.Contains(string(data), marker) {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %q in %s; log contains: %q", marker, path, string(last))
+}
+
+// TestNodeWithoutCredentialsWaitsInsteadOfDialling covers the provisioning
+// window. Every node in the cluster is expected to have a Vault entry — a
+// password node carries a username and password, a key node a username alone —
+// so an entry that has not arrived means it has not been written yet, not that
+// the node uses key auth.
+//
+// Dialling anyway would send an empty username at a real BMC and burn reconnect
+// attempts reporting an authentication problem, which is a misleading account
+// of a node that is merely early. The node must stay put, say so, and connect
+// once the entry reaches it.
+func TestNodeWithoutCredentialsWaitsInsteadOfDialling(t *testing.T) {
+	sessionCh := make(chan *sshSession)
+	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
+	id, nodeMap, passwords := singleNode(t, srv.addr())
+
+	logsDir := t.TempDir()
+	manager := newManager(t, logsDir)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Membership only — no credentials follow.
+	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
 		t.Fatal(err)
 	}
 
-	// The connection must be torn down so the node can re-authenticate. This
-	// manager has no key path, so the retry then fails and backs off — the
-	// disconnect itself is what proves the credentials were applied.
-	waitForMarker(t, clientCh, "[Console "+id+" disconnected at", 15*time.Second)
+	waitForLogMarker(t, logsDir, id, "waiting for credentials", 10*time.Second)
+
+	// Well past several reconnect intervals (250ms min, 1s max in tests), so a
+	// node that was going to dial would have done it by now.
+	time.Sleep(3 * time.Second)
+
+	if got := srv.accepts.Load(); got != 0 {
+		t.Errorf("node made %d connection attempt(s) with no credentials, want 0", got)
+	}
+	select {
+	case <-sessionCh:
+		t.Fatal("node established a session before it had any credentials")
+	default:
+	}
+
+	// The entry arrives. The node must pick it up promptly rather than after
+	// some later poll — the wait is on a signal, not a timer.
+	manager.UpdateCredentials(passwords)
+
+	select {
+	case <-sessionCh:
+	case <-time.After(15 * time.Second):
+		t.Fatal("node did not connect after its credentials arrived")
+	}
+}
+
+// TestNodesAwaitingCredentials covers the signal the credential watcher runs
+// on. A node added after startup needs its Vault entry fetched even though
+// nothing in Vault changed, so change detection alone would leave it parked;
+// the watcher asks the manager who is still waiting instead.
+func TestNodesAwaitingCredentials(t *testing.T) {
+	id, nodeMap, passwords := singleNode(t, deadAddr(t))
+
+	manager := newManager(t, t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if got := manager.NodesAwaitingCredentials(); len(got) != 0 {
+		t.Fatalf("NodesAwaitingCredentials on an empty manager = %v, want none", got)
+	}
+
+	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
+		t.Fatal(err)
+	}
+	got := manager.NodesAwaitingCredentials()
+	if len(got) != 1 || got[0] != id {
+		t.Fatalf("NodesAwaitingCredentials after adding %s = %v, want [%s]", id, got, id)
+	}
+
+	// UpdateCredentials applies synchronously, so the node has stopped waiting
+	// by the time it returns — no polling window here.
+	manager.UpdateCredentials(passwords)
+	if got := manager.NodesAwaitingCredentials(); len(got) != 0 {
+		t.Fatalf("NodesAwaitingCredentials after delivery = %v, want none", got)
+	}
+
+	// A node dropped from inventory is not waiting for anything.
+	if err := manager.UpdateNodes(ctx, map[string]*nodes.NodeConsoleInfo{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := manager.NodesAwaitingCredentials(); len(got) != 0 {
+		t.Fatalf("NodesAwaitingCredentials after removing the node = %v, want none", got)
+	}
 }

--- a/internal/ssh/scale_test.go
+++ b/internal/ssh/scale_test.go
@@ -80,9 +80,7 @@ func TestSSHConsoleManagerScale(t *testing.T) {
 
 	goroutinesBefore := runtime.NumGoroutine()
 
-	if err := manager.UpdateNodesAndCredentials(ctx, nodeMap, passwords); err != nil {
-		t.Fatalf("UpdateNodesAndCredentials: %v", err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
 	// Wait until all nodes have established a shell session on the server.
 	t.Logf("Waiting for %d nodes to connect (timeout %s)…", scaleNodeCount, scaleConnTimeout)

--- a/internal/ssh/server_test.go
+++ b/internal/ssh/server_test.go
@@ -4,16 +4,15 @@
 
 package ssh_test
 
-// In-process SSH test server and shared test helpers used across scale,
-// concurrent, and node-behaviour tests.
-
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"fmt"
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -24,35 +23,26 @@ import (
 	"github.com/OpenCHAMI/remote-console/internal/ssh"
 )
 
-// ---------------------------------------------------------------------------
-// Test credentials (shared across all tests)
-// ---------------------------------------------------------------------------
-
 const (
 	testSSHUser = "testuser"
 	testSSHPass = "testpass"
-	// testSSHPassAlt is a second valid password. Tests that need credentials to
-	// actually change (so credsChanged() flips and UpdateCreds() is reached) can
-	// alternate between the two without breaking authentication.
+	// testSSHPassAlt allows credential changes without breaking authentication.
 	testSSHPassAlt = "testpass-alt"
 )
 
-// ---------------------------------------------------------------------------
-// sshServer — in-process SSH server
-// ---------------------------------------------------------------------------
-
-// sshServer is a minimal in-process SSH server. When a client establishes a
-// shell or exec session, onShell is called in its own goroutine with the
-// accepted channel. onShell is responsible for draining the channel and closing
-// it when done. All connections share a single listener on a random loopback port.
+// sshServer is a minimal in-process server on a random loopback port. It calls onShell in a new
+// goroutine for each shell or exec session. onShell drains and closes the accepted channel.
 type sshServer struct {
 	listener net.Listener
 	cfg      *gossh.ServerConfig
 	onShell  func(ch gossh.Channel)
+
+	// accepts counts TCP connections before authentication. It is the earliest observable
+	// connection attempt.
+	accepts atomic.Int64
 }
 
-// newSSHServer starts an in-process SSH server that accepts password auth with
-// testSSHUser/testSSHPass and calls onShell for every established shell session.
+// newSSHServer starts a password-authenticated test server.
 func newSSHServer(t *testing.T, onShell func(gossh.Channel)) *sshServer {
 	t.Helper()
 
@@ -94,6 +84,7 @@ func (s *sshServer) serve() {
 		if err != nil {
 			return
 		}
+		s.accepts.Add(1)
 		go s.handleConn(conn)
 	}
 }
@@ -137,10 +128,6 @@ func (s *sshServer) handleSession(ch gossh.Channel, reqs <-chan *gossh.Request) 
 	}
 }
 
-// ---------------------------------------------------------------------------
-// sshSession — controllable session handed to tests
-// ---------------------------------------------------------------------------
-
 // sshSession gives a test direct control over one established shell session.
 type sshSession struct {
 	send chan<- []byte // write here to push bytes to the client
@@ -148,9 +135,8 @@ type sshSession struct {
 	drop func()        // close the server-side channel immediately
 }
 
-// runSession is an onShell implementation for tests that need per-session
-// control. It pumps stdin/stdout and sends the session to out, then keeps the
-// channel alive until drop is called.
+// runSession gives tests control of session input, output, and disconnection. It keeps the channel
+// open until drop is called.
 func runSession(ch gossh.Channel, out chan<- *sshSession) {
 	sendCh := make(chan []byte, 16)
 	recvCh := make(chan []byte, 16)
@@ -165,7 +151,7 @@ func runSession(ch gossh.Channel, out chan<- *sshSession) {
 		}),
 	}
 
-	// stdin → recvCh
+	// Forward client input to recvCh.
 	go func() {
 		buf := make([]byte, 4096)
 		for {
@@ -185,7 +171,7 @@ func runSession(ch gossh.Channel, out chan<- *sshSession) {
 		}
 	}()
 
-	// sendCh → stdout
+	// Forward sendCh data to client output.
 	go func() {
 		for {
 			select {
@@ -206,11 +192,7 @@ func runSession(ch gossh.Channel, out chan<- *sshSession) {
 	<-dropped
 }
 
-// ---------------------------------------------------------------------------
-// Shared test helpers
-// ---------------------------------------------------------------------------
-
-// nodeAddr parses "host:port" and returns the components.
+// nodeAddr separates a network address into its host and port.
 func nodeAddr(t *testing.T, addr string) (host string, port int) {
 	t.Helper()
 	colon := strings.LastIndex(addr, ":")
@@ -223,8 +205,7 @@ func nodeAddr(t *testing.T, addr string) (host string, port int) {
 	return addr[:colon], port
 }
 
-// singleNode builds a one-node map and matching credentials map for tests
-// that only need a single SSH node.
+// singleNode builds matching inventory and credentials for one SSH node.
 func singleNode(t *testing.T, addr string) (id string, nodeMap map[string]*nodes.NodeConsoleInfo, passwords map[string]compcredentials.CompCredentials) {
 	t.Helper()
 	host, port := nodeAddr(t, addr)
@@ -243,8 +224,23 @@ func singleNode(t *testing.T, addr string) (id string, nodeMap map[string]*nodes
 	return
 }
 
-// makePasswordsWith builds a credential map assigning the same password to
-// every id.
+// startNodes follows service ordering by registering membership before credentials. The first
+// connection attempt therefore occurs after UpdateCredentials.
+func startNodes(
+	t *testing.T,
+	manager *ssh.SSHConsoleManager,
+	ctx context.Context,
+	nodeMap map[string]*nodes.NodeConsoleInfo,
+	passwords map[string]compcredentials.CompCredentials,
+) {
+	t.Helper()
+	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
+		t.Fatalf("UpdateNodes: %v", err)
+	}
+	manager.UpdateCredentials(passwords)
+}
+
+// makePasswordsWith assigns one password to every node.
 func makePasswordsWith(ids []string, password string) map[string]compcredentials.CompCredentials {
 	m := make(map[string]compcredentials.CompCredentials, len(ids))
 	for _, id := range ids {
@@ -253,12 +249,9 @@ func makePasswordsWith(ids []string, password string) map[string]compcredentials
 	return m
 }
 
-// newManager creates an SSHConsoleManager with fast reconnect intervals
-// suitable for tests.
-//
-// Pass logsDir as t.TempDir() at the call site — see waitOnCleanup for why the
-// order matters. Callers must cancel the context they hand to
-// UpdateNodesAndCredentials/UpdateNodes with defer, which runs before this cleanup.
+// newManager creates a manager with fast reconnect intervals. logsDir must come from t.TempDir
+// before this call so manager cleanup runs first. Callers must defer cancellation of the context
+// passed to UpdateNodes.
 func newManager(t *testing.T, logsDir string) *ssh.SSHConsoleManager {
 	t.Helper()
 	cfg := ssh.DefaultSSHConfig()
@@ -270,25 +263,16 @@ func newManager(t *testing.T, logsDir string) *ssh.SSHConsoleManager {
 	return manager
 }
 
-// waitOnCleanup makes a test wait for the manager's node goroutines before it
-// finishes.
-//
-// A node opens its log file as the first thing Run does, and the manager only
-// ever asks nodes to stop. A test that hands t.TempDir() to a manager and
-// returns without waiting races its own cleanup: RemoveAll empties the
-// directory, a node goroutine gets scheduled and recreates the log file, and
-// the final rmdir fails with "directory not empty".
-//
-// Cleanups run last-in-first-out, so as long as the caller obtained logsDir
-// from t.TempDir() before reaching here, the wait happens first and the
-// directory is empty when it is removed.
+// waitOnCleanup waits for node goroutines before temporary directory cleanup. Without it, Run can
+// recreate a log after directory removal begins and cause cleanup to fail. Calling t.TempDir
+// before registering this cleanup ensures the wait runs first.
 func waitOnCleanup(t *testing.T, manager *ssh.SSHConsoleManager) {
 	t.Helper()
 	t.Cleanup(manager.Wait)
 }
 
-// waitForMarker reads from ch until the accumulated output contains marker or
-// the timeout expires. Returns the full output seen.
+// waitForMarker reads until the accumulated output contains marker or the timeout expires. It
+// returns all output received.
 func waitForMarker(t *testing.T, ch <-chan []byte, marker string, timeout time.Duration) string {
 	t.Helper()
 	timer := time.NewTimer(timeout)


### PR DESCRIPTION
Keep consoles idle until Vault provides their credentials instead of
attempting invalid key authentication. Deliver credentials independently
of inventory changes and retain timestamped, sanitized SSH console logs.

Signed-off-by: Chris Harris <cjh@lbl.gov>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>