### PR TITLE
fix(conman): harden process and credential handling

### DIFF
--- a/internal/conman/conman.go
+++ b/internal/conman/conman.go
@@ -10,6 +10,7 @@ package conman
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -20,7 +21,6 @@ import (
 	"sync"
 	"syscall"
 	"text/template"
-	"time"
 
 	"github.com/Cray-HPE/hms-compcredentials"
 
@@ -34,11 +34,7 @@ type ConmanService struct {
 }
 
 func NewConmanService(config ConmanConfig) *ConmanService {
-	return &ConmanService{
-		config:  config,
-		mutex:   sync.Mutex{},
-		command: nil,
-	}
+	return &ConmanService{config: config}
 }
 
 func (cs *ConmanService) ConfigureConman(nodeMap map[string]*nodes.NodeConsoleInfo, passwords map[string]compcredentials.CompCredentials) (bool, error) {
@@ -100,7 +96,6 @@ func generateIPMIConsoleConfig(nci *nodes.NodeConsoleInfo, creds compcredentials
 		nci.ID, nci.ConnectionHost, creds.Username, creds.Password)
 }
 
-
 func (cs *ConmanService) updateConfigFile(nodeMap map[string]*nodes.NodeConsoleInfo, passwords map[string]compcredentials.CompCredentials, forceUpdate bool) (bool, error) {
 	slog.Info("Updating conman configuration file")
 
@@ -140,16 +135,18 @@ func (cs *ConmanService) updateConfigFile(nodeMap map[string]*nodes.NodeConsoleI
 		case nodes.IPMI:
 			creds, ok := passwords[nci.ID]
 			if !ok {
-				slog.Warn("No credentials found for node", "nodeID", nci.ID)
+				// No entry for this node yet. Leaving it out beats writing a
+				// console with empty credentials, which conmand would accept and
+				// then fail to authenticate with over and over.
+				slog.Warn("No credentials found for node; leaving it out of the conman config", "nodeID", nci.ID)
+				continue
 			}
 			consoles = append(consoles, generateIPMIConsoleConfig(nci, creds))
 			ipmiCount++
 
 		case nodes.SSH:
 			// Callers filter to IPMI nodes before calling, so reaching this is a
-			// caller bug rather than routine. Skipping is still the right
-			// response: writing a conman console for an SSH node would put a
-			// second process on a console SSHConsoleManager is already driving.
+			// caller bug.
 			slog.Error("SSH node passed to conman config; skipping", "nodeID", nci.ID)
 		}
 	}
@@ -162,43 +159,50 @@ func (cs *ConmanService) updateConfigFile(nodeMap map[string]*nodes.NodeConsoleI
 		}
 	}
 
-	// Only report hasNodes=true for IPMI nodes; SSH nodes don't need conman.
+	// Only report hasNodes=true for IPMI nodes that were actually written.
+	// When that leaves nothing, runConman waits and tries again rather than
+	// starting conmand on an empty config.
 	return ipmiCount > 0, nil
 }
 
 // SignalConmanTERM sends SIGTERM to running conmand process
 func (cs *ConmanService) SignalConmanTERM() error {
-	if cs.command != nil {
-		slog.Info("Signaling conman with SIGTERM")
-		if err := cs.command.Process.Signal(syscall.SIGTERM); err != nil {
-			return fmt.Errorf("failed to signal conman with SIGTERM: %w", err)
-		}
-	} else {
-		slog.Warn("Attempting to signal conman process when nil")
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+
+	if cs.command == nil || cs.command.Process == nil {
+		slog.Debug("Conmand is not running, skipping SIGTERM")
+		return nil
 	}
-		
+
+	slog.Info("Signaling conman with SIGTERM")
+	if err := cs.command.Process.Signal(syscall.SIGTERM); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("failed to signal conman with SIGTERM: %w", err)
+	}
 	return nil
 }
 
 // SignalConmanHUP sends SIGHUP to running conmand process
 func (cs *ConmanService) SignalConmanHUP() error {
-	if cs.command != nil {
-		slog.Info("Signaling conman with SIGHUP")
-		if err := cs.command.Process.Signal(syscall.SIGHUP); err != nil {
-			return fmt.Errorf("failed to signal conman with SIGHUP: %w", err)
-		}
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+
+	if cs.command == nil || cs.command.Process == nil {
+		slog.Debug("Conmand is not running, skipping SIGHUP")
 		return nil
-	} else {
-		slog.Warn("Attempting to signal conman process when nil")
 	}
 
+	slog.Info("Signaling conman with SIGHUP")
+	if err := cs.command.Process.Signal(syscall.SIGHUP); err != nil && !errors.Is(err, os.ErrProcessDone) {
+		return fmt.Errorf("failed to signal conman with SIGHUP: %w", err)
+	}
 	return nil
 }
 
 // logPipeOutput takes the output of a pipe and logs it
-func logPipeOutput(readPipe *io.ReadCloser, desc string) {
+func logPipeOutput(readPipe io.ReadCloser, desc string) {
 	slog.Debug("Starting conmand pipe logging", "pipe", desc)
-	er := bufio.NewReader(*readPipe)
+	er := bufio.NewReader(readPipe)
 	for {
 		// read the next line
 		line, err := er.ReadString('\n')
@@ -210,35 +214,57 @@ func logPipeOutput(readPipe *io.ReadCloser, desc string) {
 	}
 }
 
+func (cs *ConmanService) startConman() (*exec.Cmd, io.ReadCloser, io.ReadCloser, error) {
+	cs.mutex.Lock()
+	defer cs.mutex.Unlock()
+
+	if cs.command != nil {
+		return nil, nil, nil, fmt.Errorf("command not nil on entry to executeConman")
+	}
+
+	command := exec.Command("conmand", "-F", "-v", "-c", cs.config.ConfFilePath)
+	cmdStdErr, err := command.StderrPipe()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("unable to connect to conmand stderr pipe: %w", err)
+	}
+	cmdStdOut, err := command.StdoutPipe()
+	if err != nil {
+		_ = cmdStdErr.Close()
+		return nil, nil, nil, fmt.Errorf("unable to connect to conmand stdout pipe: %w", err)
+	}
+
+	slog.Info("Starting conmand process")
+	if err = command.Start(); err != nil {
+		_ = cmdStdErr.Close()
+		_ = cmdStdOut.Close()
+		return nil, nil, nil, fmt.Errorf("unable to start command: %w", err)
+	}
+
+	cs.command = command
+	return command, cmdStdErr, cmdStdOut, nil
+}
+
 // ExecuteConman starts conmand and waits for it to exit
 func (cs *ConmanService) ExecuteConman() error {
 	slog.Info("Starting new instance of conmand")
-	if cs.command != nil {
-		return fmt.Errorf("command not nil on entry to executeConman")
-	}
-	cs.command = exec.Command("conmand", "-F", "-v", "-c", cs.config.ConfFilePath)
-	cmdStdErr, err := cs.command.StderrPipe()
-	if err != nil {
-		return fmt.Errorf("unable to connect to conmand stderr pipe: %w", err)
-	}
-	cmdStdOut, err := cs.command.StdoutPipe()
-	if err != nil {
-		return fmt.Errorf("unable to connect to conmand stdout pipe: %w", err)
-	}
-	go logPipeOutput(&cmdStdErr, "stderr")
-	go logPipeOutput(&cmdStdOut, "stdout")
 
-	slog.Info("Starting conmand process")
-	if err = cs.command.Start(); err != nil {
-		return fmt.Errorf("unable to start command: %w", err)
+	command, cmdStdErr, cmdStdOut, err := cs.startConman()
+	if err != nil {
+		return err
 	}
 
-	if err = cs.command.Wait(); err != nil {
+	go logPipeOutput(cmdStdErr, "stderr")
+	go logPipeOutput(cmdStdOut, "stdout")
+
+	if err = command.Wait(); err != nil {
 		slog.Error("Conmand process exited with error", "error", err)
-		time.Sleep(15 * time.Second)
 	}
 
-	cs.command = nil
+	cs.mutex.Lock()
+	if cs.command == command {
+		cs.command = nil
+	}
+	cs.mutex.Unlock()
 	slog.Info("Conmand process has exited")
 
 	return nil

--- a/internal/conman/conman_test.go
+++ b/internal/conman/conman_test.go
@@ -7,8 +7,10 @@ package conman
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Cray-HPE/hms-compcredentials"
 	"github.com/stretchr/testify/require"
@@ -119,4 +121,134 @@ console name="x0c0s1b0" dev="ipmi:x0c0s1b0" ipmiopts="U:admin,P:password1,W:solp
 	generatedConfigStr = strings.ReplaceAll(generatedConfigStr, tempDir, "")
 
 	require.Equal(t, expected, generatedConfigStr)
+}
+
+// A node whose credentials have not arrived is left out of the config rather
+// than written with empty ones. conmand would take an empty-credential console
+// and fail to authenticate on it indefinitely.
+func TestConfigureConmanSkipsNodesWithoutCredentials(t *testing.T) {
+	tempDir := t.TempDir()
+
+	config := DefaultConmanConfig()
+	config.BaseConfFilePath = "../../scripts/conman.conf.tmpl"
+	config.ConfFilePath = filepath.Join(tempDir, "conman.conf")
+	config.LogsPath = filepath.Join(tempDir, "logs")
+	config.PidFilePath = filepath.Join(tempDir, "conman.pid")
+
+	provisioned, waiting := "x0c0s1b0", "x0c0s2b0"
+	nodeMap := map[string]*nodes.NodeConsoleInfo{
+		provisioned: {ID: provisioned, ConnectionType: nodes.IPMI, ConnectionHost: provisioned},
+		waiting:     {ID: waiting, ConnectionType: nodes.IPMI, ConnectionHost: waiting},
+	}
+	passwords := map[string]compcredentials.CompCredentials{
+		provisioned: {Username: "admin", Password: "password1"},
+	}
+
+	service := NewConmanService(config)
+
+	hasNodes, err := service.ConfigureConman(nodeMap, passwords)
+	require.NoError(t, err)
+	require.True(t, hasNodes, "the node that does have credentials is still worth running conman for")
+
+	generatedConfig, err := os.ReadFile(config.ConfFilePath)
+	require.NoError(t, err)
+	require.Contains(t, string(generatedConfig), `console name="x0c0s1b0"`)
+	require.NotContains(t, string(generatedConfig), waiting,
+		"a node without credentials should not appear in the config at all")
+
+	// With nothing configurable, runConman must be told there is nothing to run.
+	service = NewConmanService(config)
+	hasNodes, err = service.ConfigureConman(nodeMap, nil)
+	require.NoError(t, err)
+	require.False(t, hasNodes, "no node could be configured, so there is no conman to start")
+}
+
+func installFakeConmand(t *testing.T, body string) {
+	t.Helper()
+
+	binDir := t.TempDir()
+	conmandPath := filepath.Join(binDir, "conmand")
+	script := "#!/bin/sh\n" + body
+	require.NoError(t, os.WriteFile(conmandPath, []byte(script), 0700)) //nolint:gosec // the test command must be executable
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestExecuteConmanClearsStateAfterExit(t *testing.T) {
+	installFakeConmand(t, "exit 0\n")
+
+	config := DefaultConmanConfig()
+	config.ConfFilePath = filepath.Join(t.TempDir(), "missing-conman.conf")
+	service := NewConmanService(config)
+
+	for range 2 {
+		require.NoError(t, service.ExecuteConman())
+
+		service.mutex.Lock()
+		require.Nil(t, service.command)
+		service.mutex.Unlock()
+	}
+}
+
+func TestSignalConmanTERM(t *testing.T) {
+	installFakeConmand(t, "trap 'exit 0' TERM\nwhile :; do sleep 1; done\n")
+
+	tempDir := t.TempDir()
+	config := DefaultConmanConfig()
+	config.BaseConfFilePath = "../../scripts/conman.conf.tmpl"
+	config.ConfFilePath = filepath.Join(tempDir, "conman.conf")
+	config.LogsPath = filepath.Join(tempDir, "logs")
+	config.PidFilePath = filepath.Join(tempDir, "conman.pid")
+	require.NoError(t, os.MkdirAll(filepath.Join(config.LogsPath, "conman"), 0755))
+
+	service := NewConmanService(config)
+	nodeID := "x0c0s1b0"
+	nodeMap := map[string]*nodes.NodeConsoleInfo{
+		nodeID: {
+			ID:             nodeID,
+			ConnectionType: nodes.IPMI,
+			ConnectionHost: "127.0.0.1",
+		},
+	}
+	passwords := map[string]compcredentials.CompCredentials{
+		nodeID: {
+			Username: "admin",
+			Password: "password",
+		},
+	}
+	hasNodes, err := service.ConfigureConman(nodeMap, passwords)
+	require.NoError(t, err)
+	require.True(t, hasNodes)
+
+	executeDone := make(chan error, 1)
+	go func() {
+		executeDone <- service.ExecuteConman()
+	}()
+
+	deadline := time.NewTimer(2 * time.Second)
+	defer deadline.Stop()
+	for {
+		service.mutex.Lock()
+		running := service.command != nil && service.command.Process != nil
+		service.mutex.Unlock()
+		if running {
+			break
+		}
+
+		select {
+		case err := <-executeDone:
+			t.Fatalf("conmand exited before it could be signaled: %v", err)
+		case <-deadline.C:
+			t.Fatal("conmand did not start")
+		default:
+			runtime.Gosched()
+		}
+	}
+	require.NoError(t, service.SignalConmanTERM())
+
+	select {
+	case err := <-executeDone:
+		require.NoError(t, err)
+	case <-time.After(3 * time.Second):
+		t.Fatal("SIGTERM did not stop conmand")
+	}
 }

--- a/test/interactive_test.go
+++ b/test/interactive_test.go
@@ -297,6 +297,66 @@ func (s *IntegrationTestSuite) TestConsoleInteractiveConmanReconnect() {
 	s.Require().Contains(output, expectedHostLine)
 }
 
+func (s *IntegrationTestSuite) TestConsoleInteractiveConmanRemoval() {
+	console := consoleFixtures["ipmi"]
+	nodeID := console.nodeID
+	ctx := context.Background()
+
+	wsConn, resp, err := s.connectInteractiveConsole(nodeID, console.prompt, 90*time.Second)
+	s.Require().NoError(err)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			s.T().Logf("Warning: failed to close response body: %v", err)
+		}
+		if err := wsConn.Close(); err != nil {
+			s.T().Logf("Warning: failed to close websocket: %v", err)
+		}
+	}()
+
+	smdAPIURL, err := getSMDAPIURL(ctx, s.containers["smd"])
+	s.Require().NoError(err)
+
+	removed := false
+	defer func() {
+		if !removed {
+			return
+		}
+		err := loadRedfishEndpoint(s.T(), context.Background(), smdAPIURL, redfishEndpoint{
+			Host:     nodeID,
+			Username: console.username,
+			Password: console.password,
+		})
+		if err != nil {
+			s.T().Errorf("Failed to restore Redfish endpoint %s: %v", nodeID, err)
+			return
+		}
+		if err := s.waitForConsoleID(nodeID, 3*time.Minute); err != nil {
+			s.T().Errorf("Remote-console did not restore console %s: %v", nodeID, err)
+		}
+	}()
+
+	err = deleteRedfishEndpoint(s.T(), ctx, smdAPIURL, nodeID)
+	s.Require().NoError(err, "failed to remove IPMI Redfish endpoint")
+	removed = true
+	s.Require().NoError(s.waitForConsoleRemoval(nodeID, 3*time.Minute),
+		"remote-console did not remove the IPMI console")
+
+	// ConMan waits for FreeIPMI to close active SOL sessions during shutdown.
+	s.Require().NoError(wsConn.SetReadDeadline(time.Now().Add(90 * time.Second)))
+	var output strings.Builder
+	for {
+		_, message, err := wsConn.ReadMessage()
+		if err != nil {
+			var closeErr *websocket.CloseError
+			s.Require().ErrorAs(err, &closeErr, "expected the removed console session to close")
+			break
+		}
+		output.Write(message)
+	}
+	s.Require().NotContains(output.String(), fmt.Sprintf("[Reconnecting to %s...]", nodeID),
+		"removed console should not reconnect")
+}
+
 func (s *IntegrationTestSuite) TestConsoleInteractiveNewNodeNoDisrupt() {
 	// Verify that adding a new SSH node does not disrupt an existing interactive session.
 	// Previously (conman era) adding a node caused conmand to restart, which briefly


### PR DESCRIPTION
Omit IPMI nodes until credentials are available instead of writing
unusable entries. Make ConMan process state and termination
deterministic, including interactive client cleanup.

Signed-off-by: Chris Harris <cjh@lbl.gov>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>