### PR TITLE
feat(ssh): add console configuration

### DIFF
--- a/cmd/remote-console/config.go
+++ b/cmd/remote-console/config.go
@@ -6,11 +6,13 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"slices"
 
 	"github.com/OpenCHAMI/remote-console/internal/conman"
 	"github.com/OpenCHAMI/remote-console/internal/creds"
 	"github.com/OpenCHAMI/remote-console/internal/logs"
+	"github.com/OpenCHAMI/remote-console/internal/ssh"
 )
 
 type OAuth2Config struct {
@@ -24,6 +26,7 @@ type remoteConsoleConfig struct {
 	Log                  logs.LogConfig `flag:"-"`
 	Conman               conman.ConmanConfig
 	Creds                creds.CredsConfig
+	SSH                  ssh.SSHConfig
 	HttpListen           string `desc:"HTTP listen address"`
 	NewNodeLookup        int    `desc:"Interval in seconds to look for new nodes"`
 	CredsMonitorInterval int    `desc:"Interval in seconds to monitor credential updates"`
@@ -38,6 +41,7 @@ func DefaultConfig() remoteConsoleConfig {
 		Log:                  logs.DefaultLogConfig(),
 		Conman:               conman.DefaultConmanConfig(),
 		Creds:                creds.DefaultCredsConfig(),
+		SSH:                  ssh.DefaultSSHConfig(),
 		HttpListen:           "0.0.0.0:26776",
 		NewNodeLookup:        120,
 		CredsMonitorInterval: 30,
@@ -72,9 +76,40 @@ func validateCredsConfig(config *remoteConsoleConfig) error {
 	return nil
 }
 
+// resolveConsoleLogsBasePath keeps the current and deprecated log path settings in sync. When
+// only one differs from the default, it wins. Conflicting explicit values are rejected.
+func resolveConsoleLogsBasePath(config *remoteConsoleConfig) error {
+	newPath := config.Log.ConsoleLogsBasePath
+	legacyPath := config.Conman.LogsPath
+	defaultPath := logs.DefaultLogConfig().ConsoleLogsBasePath
+
+	switch {
+	case newPath == legacyPath:
+		return nil
+	case legacyPath == defaultPath:
+		config.Conman.LogsPath = newPath
+		return nil
+	case newPath == defaultPath:
+		slog.Warn("conman-logs-path is deprecated, use console-logs-base-path")
+		config.Log.ConsoleLogsBasePath = legacyPath
+		return nil
+	default:
+		return fmt.Errorf("console-logs-base-path %q conflicts with deprecated conman-logs-path %q",
+			newPath, legacyPath)
+	}
+}
+
 func validateConfig(config *remoteConsoleConfig) error {
+	if err := resolveConsoleLogsBasePath(config); err != nil {
+		return err
+	}
+
 	if err := validateCredsConfig(config); err != nil {
 		return err
+	}
+
+	if err := config.SSH.Validate(); err != nil {
+		return fmt.Errorf("invalid SSH console configuration: %w", err)
 	}
 
 	// Validate OAuth2 configuration - either all or nothing

--- a/cmd/remote-console/config_test.go
+++ b/cmd/remote-console/config_test.go
@@ -1,0 +1,103 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package main
+
+import "testing"
+
+func TestCommandIncludesConsoleLogSettings(t *testing.T) {
+	config := DefaultConfig()
+	cmd := command(&config)
+	flags := make(map[string]bool)
+	for _, flag := range cmd.Flags {
+		for _, name := range flag.Names() {
+			flags[name] = true
+		}
+	}
+
+	for _, name := range []string{"console-logs-base-path", "conman-logs-path"} {
+		if !flags[name] {
+			t.Errorf("command does not provide %s", name)
+		}
+	}
+}
+
+func TestCommandOmitsSSHReconnectSettings(t *testing.T) {
+	config := DefaultConfig()
+	cmd := command(&config)
+	for _, name := range []string{"ssh-reconnect-min-interval", "ssh-reconnect-max-interval"} {
+		for _, flag := range cmd.Flags {
+			if flag.Names()[0] == name {
+				t.Errorf("command unexpectedly provides %s", name)
+			}
+		}
+	}
+}
+
+func TestResolveConsoleLogsBasePath(t *testing.T) {
+	defaultPath := DefaultConfig().Log.ConsoleLogsBasePath
+	tests := []struct {
+		name       string
+		newPath    string
+		legacyPath string
+		want       string
+		wantErr    bool
+	}{
+		{
+			name:       "defaults agree",
+			newPath:    defaultPath,
+			legacyPath: defaultPath,
+			want:       defaultPath,
+		},
+		{
+			name:       "new setting overrides legacy default",
+			newPath:    "/var/log/console",
+			legacyPath: defaultPath,
+			want:       "/var/log/console",
+		},
+		{
+			name:       "legacy setting remains supported",
+			newPath:    defaultPath,
+			legacyPath: "/var/log/legacy",
+			want:       "/var/log/legacy",
+		},
+		{
+			name:       "matching custom settings agree",
+			newPath:    "/var/log/console",
+			legacyPath: "/var/log/console",
+			want:       "/var/log/console",
+		},
+		{
+			name:       "custom settings conflict",
+			newPath:    "/var/log/console",
+			legacyPath: "/var/log/legacy",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := DefaultConfig()
+			config.Log.ConsoleLogsBasePath = tt.newPath
+			config.Conman.LogsPath = tt.legacyPath
+
+			err := resolveConsoleLogsBasePath(&config)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected conflicting settings to fail")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolve console logs base path: %v", err)
+			}
+			if config.Log.ConsoleLogsBasePath != tt.want {
+				t.Errorf("generic path = %q, want %q", config.Log.ConsoleLogsBasePath, tt.want)
+			}
+			if config.Conman.LogsPath != tt.want {
+				t.Errorf("ConMan path = %q, want %q", config.Conman.LogsPath, tt.want)
+			}
+		})
+	}
+}

--- a/internal/logs/config.go
+++ b/internal/logs/config.go
@@ -5,6 +5,7 @@
 package logs
 
 type LogConfig struct {
+	ConsoleLogsBasePath     string `desc:"Base path for console log files."`
 	ConsoleLogsFileSize     string `desc:"Maximum size of console log files before rotation."`
 	ConsoleLogsNumRotate    int    `desc:"Number of rotated console log files to keep."`
 	ConsoleLogsBackupPath   string `desc:"Path to rotated console log files."`
@@ -19,6 +20,7 @@ type LogConfig struct {
 
 func DefaultLogConfig() LogConfig {
 	return LogConfig{
+		ConsoleLogsBasePath:     "/var/log/conman",
 		LogRotateEnabled:        true,
 		ConsoleLogsFileSize:     "5M",
 		ConsoleLogsNumRotate:    2,

--- a/internal/nodes/node_console_info.go
+++ b/internal/nodes/node_console_info.go
@@ -29,6 +29,11 @@ type NodeConsoleInfo struct {
 	ConsoleEntryCommand string `json:"consoleEntryCommand"` // optional command to run after connecting
 }
 
+// IsSSH reports whether the node uses a direct SSH console connection.
+func (n *NodeConsoleInfo) IsSSH() bool {
+	return n.ConnectionType == SSH
+}
+
 func (nc NodeConsoleInfo) String() string {
 	return fmt.Sprintf("ID:%s, ConnectionType:%s, ConnectionHost:%s, ConnectionPort:%d",
 		nc.ID, nc.ConnectionType, nc.ConnectionHost, nc.ConnectionPort)

--- a/internal/ssh/config.go
+++ b/internal/ssh/config.go
@@ -1,0 +1,52 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package ssh
+
+import (
+	"fmt"
+	"time"
+)
+
+// SSHConfig configures SSH consoles.
+type SSHConfig struct {
+	TerminalType         string        `desc:"Terminal type for SSH PTY requests"`
+	TCPKeepAlive         time.Duration `desc:"TCP keepalive interval for SSH connections (0 disables)"`
+	ConnectTimeout       time.Duration `desc:"Deadline for the TCP dial and SSH handshake"`
+	ReconnectMinInterval time.Duration `flag:"-"`
+	ReconnectMaxInterval time.Duration `flag:"-"`
+}
+
+// DefaultSSHConfig returns the default SSH console settings.
+func DefaultSSHConfig() SSHConfig {
+	return SSHConfig{
+		TerminalType:         "xterm-256color",
+		TCPKeepAlive:         180 * time.Second,
+		ConnectTimeout:       30 * time.Second,
+		ReconnectMinInterval: 1 * time.Second,
+		ReconnectMaxInterval: 30 * time.Second,
+	}
+}
+
+// minReconnectInterval prevents tight reconnect loops.
+const minReconnectInterval = 250 * time.Millisecond
+
+// Validate checks SSH console settings.
+func (c SSHConfig) Validate() error {
+	if c.TerminalType == "" {
+		return fmt.Errorf("ssh-terminal-type must not be empty")
+	}
+	if c.ConnectTimeout <= 0 {
+		return fmt.Errorf("ssh-connect-timeout must be positive, got %s", c.ConnectTimeout)
+	}
+	if c.ReconnectMinInterval < minReconnectInterval {
+		return fmt.Errorf("SSH reconnect minimum interval must be at least %s, got %s",
+			minReconnectInterval, c.ReconnectMinInterval)
+	}
+	if c.ReconnectMaxInterval < c.ReconnectMinInterval {
+		return fmt.Errorf("SSH reconnect maximum interval %s must not be less than minimum interval %s",
+			c.ReconnectMaxInterval, c.ReconnectMinInterval)
+	}
+	return nil
+}

--- a/internal/ssh/config_test.go
+++ b/internal/ssh/config_test.go
@@ -1,0 +1,79 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package ssh_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/OpenCHAMI/remote-console/internal/ssh"
+)
+
+func TestSSHConfigValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		mutate  func(*ssh.SSHConfig)
+		wantErr bool
+	}{
+		{
+			name:   "defaults",
+			mutate: func(*ssh.SSHConfig) {},
+		},
+		{
+			name:   "keepalive may be disabled",
+			mutate: func(c *ssh.SSHConfig) { c.TCPKeepAlive = 0 },
+		},
+		{
+			name:    "empty terminal type",
+			mutate:  func(c *ssh.SSHConfig) { c.TerminalType = "" },
+			wantErr: true,
+		},
+		{
+			name:    "zero connect timeout",
+			mutate:  func(c *ssh.SSHConfig) { c.ConnectTimeout = 0 },
+			wantErr: true,
+		},
+		{
+			// A zero interval causes a tight reconnect loop.
+			name:    "zero reconnect min interval",
+			mutate:  func(c *ssh.SSHConfig) { c.ReconnectMinInterval = 0 },
+			wantErr: true,
+		},
+		{
+			name:    "reconnect min interval below floor",
+			mutate:  func(c *ssh.SSHConfig) { c.ReconnectMinInterval = time.Millisecond },
+			wantErr: true,
+		},
+		{
+			name: "max interval below min",
+			mutate: func(c *ssh.SSHConfig) {
+				c.ReconnectMinInterval = 10 * time.Second
+				c.ReconnectMaxInterval = 5 * time.Second
+			},
+			wantErr: true,
+		},
+		{
+			name: "max interval equal to min",
+			mutate: func(c *ssh.SSHConfig) {
+				c.ReconnectMinInterval = 5 * time.Second
+				c.ReconnectMaxInterval = 5 * time.Second
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := ssh.DefaultSSHConfig()
+			tt.mutate(&cfg)
+			err := cfg.Validate()
+			if tt.wantErr && err == nil {
+				t.Errorf("Validate() = nil, want error")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("Validate() = %v, want nil", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds the configuration foundation for managing SSH consoles directly in the service. 

This is the first PR in a stack replacing the legacy ConMan SSH helper scripts with an in-process Go SSH console manager.

### Overview

- **#92 and #93** — SSH configuration and console management
- **#94 and #95** — Console behavior, concurrency, and scale tests
- **#110 through #112** — ConMan I/O encapsulation, in-process SSH routing, and integration coverage
- **#113 through #116** — Legacy script removal and console refinements
- **#123** — Timestamped and sanitized console logs
- **#118 through #121** — Credential, inventory, and process lifecycle hardening

Review the stack from #92 upward.