### PR TITLE
test(ssh): cover concurrency and scale

### DIFF
--- a/internal/ssh/concurrent_test.go
+++ b/internal/ssh/concurrent_test.go
@@ -1,0 +1,242 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package ssh_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math/rand"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+
+	compcredentials "github.com/Cray-HPE/hms-compcredentials"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/OpenCHAMI/remote-console/internal/nodes"
+	"github.com/OpenCHAMI/remote-console/internal/ssh"
+)
+
+// TestSSHConsoleManagerConcurrent exercises concurrent access to SSHConsoleManager
+// and SSHConsole. Run with -race to catch synchronisation bugs:
+//
+//	go test -race -v -run TestSSHConsoleManagerConcurrent ./internal/ssh/ -timeout 60s
+//
+// Workers run simultaneously for concurrentDuration, each hammering a different
+// surface area:
+//
+//	attachWorker  – Attach, drain a few bytes, Detach (stresses clientsMu)
+//	writeWorker   – Write to random nodes while connections may be tearing down
+//	                (stresses connMu)
+//	credsWorker   – UpdateCredentials in a tight loop (stresses credsMu + connMu)
+//	rotateWorker  – ReopenLogs repeatedly (stresses reopenLogCh vs broadcast)
+//	updateWorker  – UpdateNodes with a shifting node set (stresses consolesMu vs
+//	                everything else)
+const (
+	concurrentNodes    = 100
+	concurrentWorkers  = 20
+	concurrentDuration = 30 * time.Second
+)
+
+func TestSSHConsoleManagerConcurrent(t *testing.T) {
+	srv := newSSHServer(t, func(ch gossh.Channel) {
+		_, _ = io.Copy(io.Discard, ch)
+		_ = ch.Close()
+	})
+	sshHost, sshPort := nodeAddr(t, srv.addr())
+
+	makeNodeMap := func(ids []string) map[string]*nodes.NodeConsoleInfo {
+		m := make(map[string]*nodes.NodeConsoleInfo, len(ids))
+		for _, id := range ids {
+			id := id
+			m[id] = &nodes.NodeConsoleInfo{
+				ID:             id,
+				ConnectionType: nodes.SSH,
+				ConnectionHost: sshHost,
+				ConnectionPort: sshPort,
+			}
+		}
+		return m
+	}
+	makePasswords := func(ids []string) map[string]compcredentials.CompCredentials {
+		return makePasswordsWith(ids, testSSHPass)
+	}
+
+	allIDs := make([]string, concurrentNodes)
+	for i := range allIDs {
+		allIDs[i] = fmt.Sprintf("concurrent-node-%d", i)
+	}
+	nodeMap := makeNodeMap(allIDs)
+	passwords := makePasswords(allIDs)
+
+	cfg := ssh.DefaultSSHConfig()
+	cfg.TCPKeepAlive = 0
+	cfg.ReconnectMinInterval = 250 * time.Millisecond
+	cfg.ReconnectMaxInterval = 500 * time.Millisecond
+
+	manager := ssh.NewSSHConsoleManager(cfg, "", t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
+		t.Fatalf("initial UpdateNodes: %v", err)
+	}
+
+	// Wait until all nodes are registered (Attach succeeds) before starting workers.
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		allUp := true
+		for _, id := range allIDs {
+			ch, err := manager.Attach(id, "probe")
+			if err != nil {
+				allUp = false
+				break
+			}
+			manager.Detach(id, "probe")
+			_ = ch
+		}
+		if allUp {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	goroutinesBefore := runtime.NumGoroutine()
+	end := time.Now().Add(concurrentDuration)
+	var wg sync.WaitGroup
+
+	// attachWorker: Attach → drain a few messages → Detach in a tight loop.
+	// Stresses clientsMu against broadcast from the Run goroutine.
+	for i := 0; i < concurrentWorkers; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(workerID)))
+			clientID := fmt.Sprintf("attach-worker-%d", workerID)
+			for time.Now().Before(end) {
+				id := allIDs[rng.Intn(len(allIDs))]
+				ch, err := manager.Attach(id, clientID)
+				if err != nil {
+					// Node may have been temporarily removed by updateWorker.
+					time.Sleep(time.Millisecond)
+					continue
+				}
+				// Drain up to 3 queued messages then detach.
+				for i := 0; i < 3; i++ {
+					select {
+					case _, ok := <-ch:
+						if !ok {
+							i = 3 // channel closed, exit drain
+						}
+					case <-time.After(5 * time.Millisecond):
+						i = 3
+					}
+				}
+				manager.Detach(id, clientID)
+			}
+		}(i)
+	}
+
+	// writeWorker: Write to random nodes.
+	// Stresses connMu against connect/disconnect cycling.
+	for i := 0; i < concurrentWorkers; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			rng := rand.New(rand.NewSource(int64(workerID + 1000)))
+			payload := fmt.Appendf(nil, "worker-%d-ping\r\n", workerID)
+			for time.Now().Before(end) {
+				id := allIDs[rng.Intn(len(allIDs))]
+				if _, err := manager.Write(id, payload); err != nil {
+					// Node removed — not a bug.
+					time.Sleep(time.Millisecond)
+				}
+			}
+		}(i)
+	}
+
+	// credsWorker: UpdateCredentials in a tight loop.
+	// Stresses credsMu and the connMu path inside UpdateCreds.
+	//
+	// The passwords must actually differ between calls. If they are identical,
+	// credsChanged() is always false, UpdateCreds() is never reached, and the
+	// worker silently tests nothing — which is how a data race between
+	// UpdateCredentials' read of node.creds and UpdateCreds' write went
+	// unnoticed here. Both values authenticate, so nodes still connect.
+	credSets := []map[string]compcredentials.CompCredentials{
+		makePasswordsWith(allIDs, testSSHPass),
+		makePasswordsWith(allIDs, testSSHPassAlt),
+	}
+	for i := 0; i < concurrentWorkers/2; i++ {
+		wg.Add(1)
+		go func(workerID int) {
+			defer wg.Done()
+			for round := 0; time.Now().Before(end); round++ {
+				manager.UpdateCredentials(credSets[round%len(credSets)])
+				time.Sleep(5 * time.Millisecond)
+			}
+		}(i)
+	}
+
+	// rotateWorker: Signal log rotation.
+	// Stresses the reopenLogCh non-blocking send against broadcast.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for time.Now().Before(end) {
+			manager.ReopenLogs()
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	// updateWorker: Shuffle the node set — remove a few nodes and restore them.
+	// Stresses consolesMu against Attach/Detach/Write happening concurrently.
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		rng := rand.New(rand.NewSource(42))
+		for time.Now().Before(end) {
+			// Drop 1–3 nodes.
+			drop := rng.Intn(3) + 1
+			skipIdx := make(map[int]bool, drop)
+			for len(skipIdx) < drop {
+				skipIdx[rng.Intn(len(allIDs))] = true
+			}
+			subset := make([]string, 0, len(allIDs)-drop)
+			for i, id := range allIDs {
+				if !skipIdx[i] {
+					subset = append(subset, id)
+				}
+			}
+			subMap := makeNodeMap(subset)
+			if err := manager.UpdateNodes(ctx, subMap, makePasswords(subset)); err != nil {
+				t.Errorf("UpdateNodes (subset): %v", err)
+			}
+			time.Sleep(20 * time.Millisecond)
+
+			// Restore the full set.
+			if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
+				t.Errorf("UpdateNodes (full): %v", err)
+			}
+			time.Sleep(20 * time.Millisecond)
+		}
+	}()
+
+	wg.Wait()
+
+	// Shut down and verify goroutines drain.
+	cancel()
+	time.Sleep(5 * time.Second)
+
+	goroutinesAfter := runtime.NumGoroutine()
+	leaked := goroutinesAfter - goroutinesBefore
+	t.Logf("Goroutines before workers: %d, after shutdown: %d, delta: %d",
+		goroutinesBefore, goroutinesAfter, leaked)
+	if leaked > 20 {
+		t.Errorf("possible goroutine leak after shutdown: %d goroutines above pre-worker baseline", leaked)
+	}
+}

--- a/internal/ssh/scale_test.go
+++ b/internal/ssh/scale_test.go
@@ -1,0 +1,132 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package ssh_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	compcredentials "github.com/Cray-HPE/hms-compcredentials"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/OpenCHAMI/remote-console/internal/nodes"
+	"github.com/OpenCHAMI/remote-console/internal/ssh"
+)
+
+const (
+	// scaleNodeCount is the number of simultaneous SSH console connections to test.
+	// Increase this to stress the manager further.
+	scaleNodeCount   = 10000
+	scaleConnTimeout = 60 * time.Second
+)
+
+// TestSSHConsoleManagerScale verifies that SSHConsoleManager can sustain
+// scaleNodeCount simultaneous SSH console connections without leaking goroutines.
+//
+// The test uses an in-process SSH server so there is no container or network
+// overhead — all connections are localhost loopback. Run with:
+//
+//	RCS_SCALE_TEST=1 go test -v -run TestSSHConsoleManagerScale ./internal/ssh/ -timeout 300s
+//
+// Skipped unless RCS_SCALE_TEST is set: 10k nodes takes minutes and blows the
+// default package timeout during a plain `go test ./...`.
+func TestSSHConsoleManagerScale(t *testing.T) {
+	if os.Getenv("RCS_SCALE_TEST") == "" {
+		t.Skip("set RCS_SCALE_TEST=1 to run the 10k-node scale test")
+	}
+
+	var sessions atomic.Int64
+	srv := newSSHServer(t, func(ch gossh.Channel) {
+		sessions.Add(1)
+		_, _ = io.Copy(io.Discard, ch)
+		_ = ch.Close()
+	})
+
+	host, port := nodeAddr(t, srv.addr())
+
+	nodeMap := make(map[string]*nodes.NodeConsoleInfo, scaleNodeCount)
+	passwords := make(map[string]compcredentials.CompCredentials, scaleNodeCount)
+	for i := 0; i < scaleNodeCount; i++ {
+		id := fmt.Sprintf("x0c0s%db0n0", i)
+		nodeMap[id] = &nodes.NodeConsoleInfo{
+			ID:             id,
+			ConnectionType: nodes.SSH,
+			ConnectionHost: host,
+			ConnectionPort: port,
+		}
+		passwords[id] = compcredentials.CompCredentials{
+			Username: testSSHUser,
+			Password: testSSHPass,
+		}
+	}
+
+	cfg := ssh.DefaultSSHConfig()
+	cfg.TCPKeepAlive = 0
+	cfg.ReconnectMinInterval = 250 * time.Millisecond
+	cfg.ReconnectMaxInterval = 2 * time.Second
+
+	manager := ssh.NewSSHConsoleManager(cfg, "", t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	goroutinesBefore := runtime.NumGoroutine()
+
+	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
+		t.Fatalf("UpdateNodes: %v", err)
+	}
+
+	// Wait until all nodes have established a shell session on the server.
+	t.Logf("Waiting for %d nodes to connect (timeout %s)…", scaleNodeCount, scaleConnTimeout)
+	deadline := time.Now().Add(scaleConnTimeout)
+	for time.Now().Before(deadline) {
+		if sessions.Load() >= int64(scaleNodeCount) {
+			break
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	connected := sessions.Load()
+	if connected < int64(scaleNodeCount) {
+		t.Errorf("only %d/%d nodes connected within %s", connected, scaleNodeCount, scaleConnTimeout)
+	} else {
+		t.Logf("All %d nodes connected", connected)
+	}
+
+	// Goroutines per node include the SSH library internals (transport reader/
+	// writer, channel mux, global-request handler) on both client and server
+	// sides, plus explicit goroutines (Run, session.Wait, handleConn,
+	// handleSession, DiscardRequests). Flag only if we see more than 25/node,
+	// which would indicate something structurally wrong.
+	goroutinesPeak := runtime.NumGoroutine()
+	goroutinesAdded := goroutinesPeak - goroutinesBefore
+	t.Logf("Goroutines added: %d (%.1f per node)", goroutinesAdded, float64(goroutinesAdded)/float64(scaleNodeCount))
+
+	const maxGoroutinesPerNode = 25
+	if goroutinesAdded > scaleNodeCount*maxGoroutinesPerNode {
+		t.Errorf("goroutine count looks high: %d added for %d nodes (limit %d/node)",
+			goroutinesAdded, scaleNodeCount, maxGoroutinesPerNode)
+	}
+
+	// Cancel the manager context and give goroutines time to drain.
+	// Cancellation closes all SSH clients, which unblocks streamStdout's Read
+	// and lets every Run goroutine exit cleanly.
+	cancel()
+	time.Sleep(5 * time.Second)
+
+	goroutinesAfter := runtime.NumGoroutine()
+	goroutinesLeaked := goroutinesAfter - goroutinesBefore
+	t.Logf("Goroutines remaining after shutdown: %d leaked", goroutinesLeaked)
+
+	const maxLeakedGoroutines = 20
+	if goroutinesLeaked > maxLeakedGoroutines {
+		t.Errorf("possible goroutine leak after shutdown: %d goroutines above baseline", goroutinesLeaked)
+	}
+}

--- a/internal/ssh/server_test.go
+++ b/internal/ssh/server_test.go
@@ -243,6 +243,16 @@ func singleNode(t *testing.T, addr string) (id string, nodeMap map[string]*nodes
 	return
 }
 
+// makePasswordsWith builds a credential map assigning the same password to
+// every id.
+func makePasswordsWith(ids []string, password string) map[string]compcredentials.CompCredentials {
+	m := make(map[string]compcredentials.CompCredentials, len(ids))
+	for _, id := range ids {
+		m[id] = compcredentials.CompCredentials{Username: testSSHUser, Password: password}
+	}
+	return m
+}
+
 // newManager creates an SSHConsoleManager with fast reconnect intervals
 // suitable for tests.
 func newManager(t *testing.T, logsDir string) *ssh.SSHConsoleManager {


### PR DESCRIPTION
Stress concurrent manager operations, repeated updates, client churn, and larger managed node sets.
