### PR TITLE
feat(console): route SSH consoles in process

### DIFF
--- a/cmd/remote-console/service.go
+++ b/cmd/remote-console/service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/OpenCHAMI/remote-console/internal/creds"
 	"github.com/OpenCHAMI/remote-console/internal/logs"
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
+	"github.com/OpenCHAMI/remote-console/internal/ssh"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
@@ -50,10 +51,53 @@ type LogsService interface {
 	AggregateFiles(consoleLogsPath string, nodes map[string]*nodes.NodeConsoleInfo)
 }
 
+// SSHConsoleService defines the management interface for the SSH console manager.
+// Interactive access (Attach/Detach/Write) flows through the console.SSHManager
+// interface, which is passed directly to console.SetupRoutes.
+type SSHConsoleService interface {
+	UpdateNodes(ctx context.Context, sshNodes map[string]*nodes.NodeConsoleInfo,
+		passwords map[string]compcreds.CompCredentials) error
+	UpdateCredentials(passwords map[string]compcreds.CompCredentials)
+	ReopenLogs()
+}
+
+// filterSSHNodes returns the subset of nodes with SSH connection type.
+func filterSSHNodes(allNodes map[string]*nodes.NodeConsoleInfo) map[string]*nodes.NodeConsoleInfo {
+	result := make(map[string]*nodes.NodeConsoleInfo)
+	for id, n := range allNodes {
+		if n.IsSSH() {
+			result[id] = n
+		}
+	}
+	return result
+}
+
+// filterIPMINodes returns the subset of nodes with IPMI connection type.
+func filterIPMINodes(allNodes map[string]*nodes.NodeConsoleInfo) map[string]*nodes.NodeConsoleInfo {
+	result := make(map[string]*nodes.NodeConsoleInfo)
+	for id, n := range allNodes {
+		if n.ConnectionType == nodes.IPMI {
+			result[id] = n
+		}
+	}
+	return result
+}
+
+// filterXNames returns the xnames from a node map.
+func filterXNames(sshNodes map[string]*nodes.NodeConsoleInfo) []string {
+	xnames := make([]string, 0, len(sshNodes))
+	for id := range sshNodes {
+		xnames = append(xnames, id)
+	}
+	return xnames
+}
+
 // Watch for node updates and signal conman and log rotation as needed
-func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpClient *http.Client, conmanService ConmanService, logsService LogsService) {
-	// conman will add the conman directory, so we point the logs service their
-	conmanLogsPath := filepath.Join(config.Conman.LogsPath, "conman")
+func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpClient *http.Client,
+	conmanService ConmanService, logsService LogsService,
+	credsService CredsService, sshService SSHConsoleService) {
+	// ConMan writes console files in a conman subdirectory.
+	consoleLogsPath := filepath.Join(config.Log.ConsoleLogsBasePath, "conman")
 
 	ticker := time.NewTicker(time.Duration(config.NewNodeLookup) * time.Second)
 	defer ticker.Stop()
@@ -67,29 +111,45 @@ func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpC
 			changed := nodes.CheckForUpdates(ctx, httpClient, config.SmdURL)
 
 			if changed {
-				slog.Info("Node changes detected, signaling conman to restart")
+				slog.Info("Node changes detected, reconfiguring services")
+
+				currentNodes := nodes.CurrentNodes()
+				passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(currentNodes), 15, 10)
+				if err != nil {
+					slog.Error("Failed to fetch credentials for updated nodes", "error", err)
+				} else {
+					// Regenerate conman config with the new node list and credentials.
+					if _, err := conmanService.ConfigureConman(filterIPMINodes(currentNodes), passwords, config.Creds.SshConsoleKeyPath); err != nil {
+						slog.Error("Failed to reconfigure conman", "error", err)
+					}
+					// Update SSH nodes with current topology and credentials.
+					if err := sshService.UpdateNodes(ctx, filterSSHNodes(currentNodes), passwords); err != nil {
+						slog.Error("Failed to update SSH console manager", "error", err)
+					}
+				}
+
+				// Restart conman to pick up the new config.
 				if err := conmanService.SignalConmanTERM(); err != nil {
 					slog.Error("Failed to signal conman with SIGTERM", "error", err)
 				}
 
-				nodes := nodes.CurrentNodes()
-
-				// also update log rotation configuration
+				// Update log rotation configuration.
 				slog.Info("Updating log rotation configuration for node changes")
-				if err := logsService.UpdateLogRotateConf(conmanLogsPath, nodes); err != nil {
+				if err := logsService.UpdateLogRotateConf(consoleLogsPath, currentNodes); err != nil {
 					slog.Error("Failed to update log rotation configuration for node changes", "error", err)
 				}
 
 				// make sure we are aggregating any new console log files
 				slog.Info("Updating log aggregation configuration for node changes")
-				logsService.AggregateFiles(conmanLogsPath, nodes)
+				logsService.AggregateFiles(consoleLogsPath, currentNodes)
 			}
 		}
 	}
 }
 
-// Watch for credential updates and signal conman as needed
-func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig, credsService CredsService, conmanService ConmanService) {
+// Watch for credential updates and signal conman and SSH manager as needed
+func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig,
+	credsService CredsService, conmanService ConmanService, sshService SSHConsoleService) {
 	ticker := time.NewTicker(time.Duration(config.CredsMonitorInterval) * time.Second)
 	defer ticker.Stop()
 
@@ -105,7 +165,22 @@ func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig, credsS
 			}
 
 			if changed {
-				slog.Info("Credential changes detected, signaling conman to restart")
+				slog.Info("Credential changes detected, reconfiguring services")
+
+				currentNodes := nodes.CurrentNodes()
+				passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(currentNodes), 3, 5)
+				if err != nil {
+					slog.Error("Failed to fetch updated credentials", "error", err)
+				} else {
+					// Regenerate conman config so IPMI nodes pick up the new credentials.
+					if _, err := conmanService.ConfigureConman(filterIPMINodes(currentNodes), passwords, config.Creds.SshConsoleKeyPath); err != nil {
+						slog.Error("Failed to reconfigure conman with updated credentials", "error", err)
+					}
+					// Push updated credentials to SSH nodes.
+					sshService.UpdateCredentials(passwords)
+				}
+
+				// Always restart conman regardless of config update outcome.
 				if err := conmanService.SignalConmanTERM(); err != nil {
 					slog.Error("Failed to signal conman with SIGTERM", "error", err)
 				}
@@ -115,7 +190,7 @@ func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig, credsS
 }
 
 // Log rotation setup and loop
-func logRotate(ctx context.Context, config remoteConsoleConfig, conmanService ConmanService, logsService LogsService) {
+func logRotate(ctx context.Context, config remoteConsoleConfig, conmanService ConmanService, logsService LogsService, sshService SSHConsoleService) {
 	logConfig := config.Log
 	// log the log rotation parameters
 	slog.Info("Log rotation configuration",
@@ -126,11 +201,11 @@ func logRotate(ctx context.Context, config remoteConsoleConfig, conmanService Co
 		"aggFileSize", logConfig.AggLogsFileSize,
 		"aggNumRotate", logConfig.AggLogsNumRotate)
 
-	// conman will add the conman directory, so we point the logs service their
-	conmanLogsPath := filepath.Join(config.Conman.LogsPath, "conman")
+	// ConMan writes console files in a conman subdirectory.
+	consoleLogsPath := filepath.Join(config.Log.ConsoleLogsBasePath, "conman")
 
 	// Create the log rotation configuration file
-	if err := logsService.UpdateLogRotateConf(conmanLogsPath, nodes.CurrentNodes()); err != nil {
+	if err := logsService.UpdateLogRotateConf(consoleLogsPath, nodes.CurrentNodes()); err != nil {
 		slog.Error("Failed to update log rotation configuration", "error", err)
 	}
 
@@ -151,12 +226,13 @@ func logRotate(ctx context.Context, config remoteConsoleConfig, conmanService Co
 			slog.Info("Exiting log rotation loop due to shutdown")
 			return
 		case <-ticker.C:
-			restartConman := logsService.LogRotate(conmanLogsPath)
-			if restartConman {
-				slog.Info("Log files rotated, signaling conmand")
+			consoleLogsRotated := logsService.LogRotate(consoleLogsPath)
+			if consoleLogsRotated {
+				slog.Info("Log files rotated, signalling conmand and SSH manager")
 				if err := conmanService.SignalConmanHUP(); err != nil {
 					slog.Error("Failed to signal conman with SIGHUP", "error", err)
 				}
+				sshService.ReopenLogs()
 			}
 		}
 	}
@@ -183,21 +259,21 @@ func runConman(ctx context.Context, config remoteConsoleConfig, conmanService Co
 		}
 
 		currentNodes := nodes.CurrentNodes()
+		ipmiNodes := filterIPMINodes(currentNodes)
 
-		var requireCredentials []string
-		for _, nci := range currentNodes {
-			requireCredentials = append(requireCredentials, nci.ID)
-		}
-
-		passwords, err := credService.GetPasswordsWithRetries(ctx, requireCredentials, 15, 10)
-		if err != nil {
-			slog.Warn("Credential retrieval ended early", "error", err)
-			if errors.Is(err, context.Canceled) {
-				return
+		var passwords map[string]compcreds.CompCredentials
+		var err error
+		if len(ipmiNodes) > 0 {
+			passwords, err = credService.GetPasswordsWithRetries(ctx, filterXNames(ipmiNodes), 15, 10)
+			if err != nil {
+				slog.Warn("Credential retrieval ended early", "error", err)
+				if errors.Is(err, context.Canceled) {
+					return
+				}
 			}
 		}
 
-		hasNodes, err := conmanService.ConfigureConman(currentNodes, passwords, config.Creds.SshConsoleKeyPath)
+		hasNodes, err := conmanService.ConfigureConman(ipmiNodes, passwords, config.Creds.SshConsoleKeyPath)
 		if err != nil {
 			slog.Error("Failed to configure conman", "error", err)
 			if waitWithContext(5 * time.Second) {
@@ -232,11 +308,10 @@ func runService(config remoteConsoleConfig) error {
 
 	conmanService := conman.NewConmanService(config.Conman)
 
-	// Conman will append "conman" to this path for its logs, so we
-	// need to pass that full path to service monitoring the logs
-	conmanLogsPath := filepath.Join(config.Conman.LogsPath, "conman")
-	if err := os.MkdirAll(conmanLogsPath, 0755); err != nil {
-		slog.Error("Failed to create console logs directory", "path", conmanLogsPath, "error", err)
+	// ConMan writes console files in a conman subdirectory.
+	consoleLogsPath := filepath.Join(config.Log.ConsoleLogsBasePath, "conman")
+	if err := os.MkdirAll(consoleLogsPath, 0755); err != nil {
+		slog.Error("Failed to create console logs directory", "path", consoleLogsPath, "error", err)
 		return err
 	}
 
@@ -288,17 +363,31 @@ func runService(config remoteConsoleConfig) error {
 		}
 	}
 
+	// Create the SSH console manager.
+	sshManager := ssh.NewSSHConsoleManager(config.SSH, config.Creds.SshConsoleKeyPath, consoleLogsPath)
+
+	// Seed SSH nodes immediately — watchForNodesUpdates only fires after the first tick.
+	initialSSHNodes := filterSSHNodes(nodes.CurrentNodes())
+	if len(initialSSHNodes) > 0 {
+		initialXNames := filterXNames(initialSSHNodes)
+		if passwords, err := credsService.GetPasswordsWithRetries(serviceCtx, initialXNames, 15, 10); err != nil {
+			slog.Warn("Failed to fetch initial SSH credentials", "error", err)
+		} else if err := sshManager.UpdateNodes(serviceCtx, initialSSHNodes, passwords); err != nil {
+			slog.Error("Failed initial SSH manager node update", "error", err)
+		}
+	}
+
 	// goroutine for log rotation
-	go logRotate(serviceCtx, config, conmanService, logsService)
+	go logRotate(serviceCtx, config, conmanService, logsService, sshManager)
 
 	// goroutine to watches for changes in console configuration
-	go watchForNodesUpdates(serviceCtx, config, smdHTTPClient, conmanService, logsService)
+	go watchForNodesUpdates(serviceCtx, config, smdHTTPClient, conmanService, logsService, credsService, sshManager)
 
 	// goroutine to run conman
 	go runConman(serviceCtx, config, conmanService, credsService)
 
 	// goroutine watch for credential updates
-	go watchForCredUpdates(serviceCtx, config, credsService, conmanService)
+	go watchForCredUpdates(serviceCtx, config, credsService, conmanService, sshManager)
 
 	// Initialize JWT token authorization if JWKS URL is provided
 	if config.JwksURL != "" {
@@ -342,7 +431,7 @@ func runService(config remoteConsoleConfig) error {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
 
-	router := console.SetupRoutes(conmanLogsPath)
+	router := console.SetupRoutes(consoleLogsPath, sshManager)
 
 	slog.Info("Starting HTTP server", "address", config.HttpListen)
 	server := &http.Server{Addr: config.HttpListen, Handler: router}

--- a/internal/conman/config.go
+++ b/internal/conman/config.go
@@ -7,7 +7,7 @@ package conman
 type ConmanConfig struct {
 	BaseConfFilePath   string `desc:"Path to the base conman configuration template file."`
 	ConfFilePath       string `desc:"Path to the generated conman configuration file."`
-	LogsPath           string `desc:"Path to conman log files."`
+	LogsPath           string `desc:"Deprecated alias for console-logs-base-path."`
 	PidFilePath        string `desc:"Path to the conman PID file."`
 	ConsoleScriptsPath string `desc:"Path to console helper scripts."`
 }

--- a/internal/conman/conman.go
+++ b/internal/conman/conman.go
@@ -10,7 +10,6 @@ package conman
 import (
 	"bufio"
 	"bytes"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"log/slog"
@@ -101,27 +100,6 @@ func generateIPMIConsoleConfig(nci *nodes.NodeConsoleInfo, creds compcredentials
 		nci.ID, nci.ConnectionHost, creds.Username, creds.Password)
 }
 
-func (cs *ConmanService) generateSSHConsoleConfig(nci *nodes.NodeConsoleInfo, creds compcredentials.CompCredentials, sshConsoleKeyPath string) string {
-	var devArgs string
-
-	// If we have password creds, use those, otherwise use key-based.
-	if creds.Password != "" {
-		slog.Debug("Configuring SSH console with password", "nodeID", nci.ID, "host", nci.ConnectionHost, "port", nci.ConnectionPort, "username", creds.Username, "entryCmd", nci.ConsoleEntryCommand)
-		devArgs = fmt.Sprintf("%s/ssh-pwd-console %s %d %s %s", cs.config.ConsoleScriptsPath, nci.ConnectionHost, nci.ConnectionPort, creds.Username, creds.Password)
-	} else {
-		// Key based auth, note that we still use the username from the secure store.
-		slog.Debug("Configuring SSH console with key", "nodeID", nci.ID, "host", nci.ConnectionHost, "port", nci.ConnectionPort, "username", creds.Username, "keyPath", sshConsoleKeyPath, "entryCmd", nci.ConsoleEntryCommand)
-		devArgs = fmt.Sprintf("%s/ssh-key-console %s %d %s %s", cs.config.ConsoleScriptsPath, nci.ConnectionHost, nci.ConnectionPort, creds.Username, sshConsoleKeyPath)
-	}
-
-	if nci.ConsoleEntryCommand != "" {
-		// Encode the entry command in base64 to avoid issues with special characters, conman can't handle escaping quotes.
-		base64EncodedCmd := base64.StdEncoding.EncodeToString([]byte(nci.ConsoleEntryCommand))
-		devArgs = fmt.Sprintf("%s %s", devArgs, base64EncodedCmd)
-	}
-
-	return fmt.Sprintf("console name=\"%s\" dev=\"%s\"\n", nci.ID, devArgs)
-}
 
 func (cs *ConmanService) updateConfigFile(nodeMap map[string]*nodes.NodeConsoleInfo, passwords map[string]compcredentials.CompCredentials, sshConsoleKeyPath string, forceUpdate bool) (bool, error) {
 	slog.Info("Updating conman configuration file")
@@ -155,23 +133,24 @@ func (cs *ConmanService) updateConfigFile(nodeMap map[string]*nodes.NodeConsoleI
 	slog.Info("Populating conman configuration with nodes", "nodeCount", len(nodeMap))
 
 	consoles := make([]string, 0, len(nodeMap))
+	ipmiCount := 0
 
 	for _, nci := range nodeMap {
-		creds, ok := passwords[nci.ID]
-		if !ok {
-			slog.Warn("No credentials found for node", "nodeID", nci.ID)
-		}
-
 		switch nci.ConnectionType {
-		// IPMI connection
 		case nodes.IPMI:
-			output := generateIPMIConsoleConfig(nci, creds)
-			consoles = append(consoles, output)
+			creds, ok := passwords[nci.ID]
+			if !ok {
+				slog.Warn("No credentials found for node", "nodeID", nci.ID)
+			}
+			consoles = append(consoles, generateIPMIConsoleConfig(nci, creds))
+			ipmiCount++
 
-		// SSH connection
 		case nodes.SSH:
-			output := cs.generateSSHConsoleConfig(nci, creds, sshConsoleKeyPath)
-			consoles = append(consoles, output)
+			// Callers filter to IPMI nodes before calling, so reaching this is a
+			// caller bug rather than routine. Skipping is still the right
+			// response: writing a conman console for an SSH node would put a
+			// second process on a console SSHConsoleManager is already driving.
+			slog.Error("SSH node passed to conman config; skipping", "nodeID", nci.ID)
 		}
 	}
 
@@ -183,7 +162,8 @@ func (cs *ConmanService) updateConfigFile(nodeMap map[string]*nodes.NodeConsoleI
 		}
 	}
 
-	return len(nodeMap) > 0, nil
+	// Only report hasNodes=true for IPMI nodes; SSH nodes don't need conman.
+	return ipmiCount > 0, nil
 }
 
 // SignalConmanTERM sends SIGTERM to running conmand process

--- a/internal/conman/conman_test.go
+++ b/internal/conman/conman_test.go
@@ -99,6 +99,8 @@ func TestConfigureConman(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, generatedConfig)
 
+	// SSH nodes (x0c0s2b0, x0c0s3b0) are managed by SSHConsoleManager and must
+	// not appear in the conman config.
 	expected := `# UPDATE_CONFIG=TRUE
 SERVER keepalive=ON
 SERVER logdir="/logs"
@@ -111,8 +113,6 @@ GLOBAL seropts="115200,8n1"
 GLOBAL log="conman/console.%N"
 GLOBAL logopts="sanitize,timestamp"
 console name="x0c0s1b0" dev="ipmi:x0c0s1b0" ipmiopts="U:admin,P:password1,W:solpayloadsize"
-console name="x0c0s2b0" dev="/usr/bin/ssh-key-console x0c0s2b0 2222 admin /tmp/ssh_console_key"
-console name="x0c0s3b0" dev="/usr/bin/ssh-pwd-console x0c0s3b0 0 admin password3"
 `
 	// Remove temporary directory path from generated config for comparison
 	generatedConfigStr := string(generatedConfig)

--- a/internal/console/conman_backend.go
+++ b/internal/console/conman_backend.go
@@ -1,0 +1,241 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package console
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/OpenCHAMI/remote-console/internal/nodes"
+	"github.com/creack/pty"
+)
+
+// conmanConsoleIO implements consoleIO for IPMI nodes managed by conman.
+// It runs a goroutine that keeps a conman process alive, reconnecting automatically.
+type conmanConsoleIO struct {
+	nodeID string
+
+	mu   sync.Mutex
+	cmd  *exec.Cmd
+	ptmx *os.File
+
+	out    chan []byte
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	closeOnce sync.Once
+}
+
+// newConmanConsoleIO creates and starts a conmanConsoleIO for nodeID.
+func newConmanConsoleIO(nodeID string) (*conmanConsoleIO, error) {
+	if !nodes.IsCurrentNode(nodeID) {
+		return nil, fmt.Errorf("node %s is not a current node", nodeID)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &conmanConsoleIO{
+		nodeID: nodeID,
+		out:    make(chan []byte, 256),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	go c.run()
+	return c, nil
+}
+
+// run is the internal goroutine that manages the conman process lifecycle.
+func (c *conmanConsoleIO) run() {
+	defer close(c.out)
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		default:
+		}
+
+		if err := c.startProcess(); err != nil {
+			slog.Error("Failed to start conman process", "nodeID", c.nodeID, "error", err)
+			select {
+			case <-time.After(time.Second):
+			case <-c.ctx.Done():
+				return
+			}
+			continue
+		}
+
+		c.readLoop()
+
+		// Process exited. Clean up.
+		c.mu.Lock()
+		c.ptmx = nil
+		c.cmd = nil
+		c.mu.Unlock()
+
+		// Notify the client and wait before reconnecting.
+		reconnectMsg := fmt.Sprintf("\n[Reconnecting to %s...]\n", c.nodeID)
+		select {
+		case c.out <- []byte(reconnectMsg):
+		case <-c.ctx.Done():
+			return
+		}
+
+		select {
+		case <-time.After(time.Second):
+		case <-c.ctx.Done():
+			return
+		}
+
+		if !nodes.IsCurrentNode(c.nodeID) {
+			slog.Info("Node no longer in inventory, stopping conman backend", "nodeID", c.nodeID)
+			return
+		}
+	}
+}
+
+// startProcess launches a new conman process with a PTY.
+func (c *conmanConsoleIO) startProcess() error {
+	select {
+	case <-c.ctx.Done():
+		return fmt.Errorf("context cancelled")
+	default:
+	}
+
+	cmd := exec.Command("conman", c.nodeID)
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		return fmt.Errorf("pty.Start conman: %w", err)
+	}
+
+	c.mu.Lock()
+	c.cmd = cmd
+	c.ptmx = ptmx
+	c.mu.Unlock()
+
+	// Reap the child process to prevent zombies.
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			slog.Debug("conman process exited", "nodeID", c.nodeID, "error", err)
+		}
+	}()
+
+	return nil
+}
+
+// readLoop reads PTY output and sends it to the output channel.
+func (c *conmanConsoleIO) readLoop() {
+	buf := make([]byte, 4096)
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		default:
+		}
+
+		c.mu.Lock()
+		ptmx := c.ptmx
+		c.mu.Unlock()
+
+		if ptmx == nil {
+			return
+		}
+
+		ready, err := waitForPTYReadable(int(ptmx.Fd()), 250*time.Millisecond)
+		if err != nil {
+			return
+		}
+		if !ready {
+			continue
+		}
+
+		n, err := ptmx.Read(buf)
+		if n > 0 {
+			data := make([]byte, n)
+			copy(data, buf[:n])
+			select {
+			case c.out <- data:
+			case <-c.ctx.Done():
+				return
+			}
+		}
+		if err != nil {
+			if err.Error() != "EOF" && !isEIO(err) {
+				slog.Error("PTY read error", "nodeID", c.nodeID, "error", err)
+			}
+			return
+		}
+	}
+}
+
+func (c *conmanConsoleIO) Output() <-chan []byte { return c.out }
+
+func (c *conmanConsoleIO) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	ptmx := c.ptmx
+	c.mu.Unlock()
+
+	if ptmx == nil {
+		return len(p), nil // silent drop during reconnect
+	}
+	return ptmx.Write(p)
+}
+
+func (c *conmanConsoleIO) Close() error {
+	c.closeOnce.Do(func() {
+		c.mu.Lock()
+		ptmx := c.ptmx
+		cmd := c.cmd
+		c.mu.Unlock()
+
+		if ptmx != nil {
+			// Send ConMan escape to gracefully disconnect.
+			_, _ = ptmx.Write([]byte("&."))
+			time.Sleep(100 * time.Millisecond)
+			_ = ptmx.Close()
+		}
+		if cmd != nil && cmd.Process != nil {
+			_ = cmd.Process.Signal(syscall.SIGTERM)
+		}
+
+		c.cancel()
+	})
+	return nil
+}
+
+// isEIO checks if an error is EIO (expected when a PTY process exits).
+func isEIO(err error) bool {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == syscall.EIO
+	}
+	return false
+}
+
+// waitForPTYReadable waits until the PTY fd is readable or the timeout elapses.
+func waitForPTYReadable(fd int, timeout time.Duration) (bool, error) {
+	var readSet unix.FdSet
+	readSet.Zero()
+	readSet.Set(fd)
+
+	tv := unix.NsecToTimeval(timeout.Nanoseconds())
+	n, err := unix.Select(fd+1, &readSet, nil, nil, &tv)
+	if err != nil {
+		if errors.Is(err, syscall.EINTR) {
+			return false, nil
+		}
+		return false, err
+	}
+	return n > 0, nil
+}

--- a/internal/console/consoleio.go
+++ b/internal/console/consoleio.go
@@ -1,0 +1,18 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package console
+
+// consoleIO abstracts the underlying console backend (PTY/conman or SSH).
+// Implementations handle reconnection internally; Output() is closed only on
+// permanent shutdown (context cancelled or node removed from inventory).
+type consoleIO interface {
+	// Output returns a channel of console output chunks. The channel is closed
+	// when the backend shuts down permanently.
+	Output() <-chan []byte
+	// Write sends data to the console (user input).
+	Write(p []byte) (n int, err error)
+	// Close shuts down the backend. Safe to call multiple times.
+	Close() error
+}

--- a/internal/console/interactive.go
+++ b/internal/console/interactive.go
@@ -6,21 +6,14 @@ package console
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
-	"os"
-	"os/exec"
 	"sync"
-	"syscall"
 	"time"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
-	"github.com/creack/pty"
+	"github.com/OpenCHAMI/remote-console/internal/ssh"
 	"github.com/gorilla/websocket"
 	"github.com/nxadm/tail/ratelimiter"
 )
@@ -62,281 +55,80 @@ func (s *interactiveSessions) release(nodeID string) {
 	delete(s.active, nodeID)
 }
 
-// interactiveConsoleSession manages the lifecycle of an interactive console session
+// interactiveConsoleSession manages the lifecycle of an interactive console session.
 type interactiveConsoleSession struct {
-	cmd       *exec.Cmd
-	ptmx      *os.File
-	ptmxMutex sync.RWMutex // Protects ptmx during reconnection
-	nodeID    string
-
-	cancel context.CancelFunc
-
-	ws            *webSocketSession        // WebSocket session
-	rateLimiter   *ratelimiter.LeakyBucket // Rate limit console output
-	wg            sync.WaitGroup           // Tracks all goroutines
-	processExited chan struct{}            // Closed when current conman process exits
+	io          consoleIO
+	nodeID      string
+	cancel      context.CancelFunc
+	ws          *webSocketSession        // WebSocket session
+	rateLimiter *ratelimiter.LeakyBucket // Rate limit console output
+	wg          sync.WaitGroup           // Tracks all goroutines
 }
 
-// close performs graceful shutdown of the console session
-// This method is idempotent and safe to call multiple times
+// close shuts down the session. Safe to call multiple times.
 func (s *interactiveConsoleSession) close() {
 	s.closeWithReason(sessionCloseNormal, "")
 }
 
-// closeWithReason performs graceful shutdown of the console session with a specific reason
+// closeWithReason shuts down the session with a specific WebSocket close reason.
 func (s *interactiveConsoleSession) closeWithReason(reason sessionCloseReason, message string) {
-	slog.Info("Starting close for console session", "nodeID", s.nodeID)
+	slog.Info("Closing interactive console session", "nodeID", s.nodeID)
 
-	// Cancel context to signal all goroutines to stop
+	// 1. Shut down the backend (SSH detach or PTY SIGTERM). Idempotent.
+	if err := s.io.Close(); err != nil {
+		slog.Debug("Error closing console IO", "nodeID", s.nodeID, "error", err)
+	}
+
+	// 2. Cancel the session context to unblock both goroutines.
 	if s.cancel != nil {
 		s.cancel()
 	}
 
-	// Try graceful disconnect via ConMan escape sequence
-	s.ptmxMutex.RLock()
-	ptmx := s.ptmx
-	s.ptmxMutex.RUnlock()
-
-	if ptmx != nil {
-		slog.Info("Sending ConMan escape sequence (&.) to disconnect from console", "nodeID", s.nodeID)
-		// Ignore write errors - PTY might already be closed
-		if _, err := ptmx.Write([]byte("&.")); err != nil {
-			slog.Debug("Failed to write ConMan escape sequence", "nodeID", s.nodeID, "error", err)
-		}
-		time.Sleep(100 * time.Millisecond) // Brief pause to let it process
-	}
-
-	// Signal process termination (idempotent - safe to signal multiple times)
-	if s.cmd != nil && s.cmd.Process != nil {
-		slog.Info("Sending SIGTERM to conman process for console", "nodeID", s.nodeID)
-		// Ignore signal errors - process might already be dead
-		if err := s.cmd.Process.Signal(syscall.SIGTERM); err != nil {
-			slog.Debug("Failed to signal conman process", "nodeID", s.nodeID, "error", err)
-		}
-	}
-
-	// Close PTY - this will cause streamOutput to exit
-	s.ptmxMutex.Lock()
-	if s.ptmx != nil {
-		// Close returns error if already closed, but that's fine
-		if err := s.ptmx.Close(); err != nil {
-			slog.Debug("Failed to close PTY", "nodeID", s.nodeID, "error", err)
-		}
-		s.ptmx = nil
-	}
-	s.ptmxMutex.Unlock()
-
-	// Close WebSocket
+	// 3. Send a WebSocket close frame. This causes writePump to close the
+	//    underlying TCP connection, which unblocks streamInput's ReadMessage.
 	s.ws.close(reason, message)
-
-	slog.Info("Close completed for console session", "nodeID", s.nodeID)
 }
 
-// monitorProcess watches for process exit (conman) and attempts reconnection if node still exists
-// This runs in a loop, monitoring each new process after successful reconnection
-func (s *interactiveConsoleSession) monitorProcess(ctx context.Context) {
-	for {
-		select {
-		case <-s.processExited:
-		case <-ctx.Done():
-			slog.Info("Session closing, stopping monitor for console", "nodeID", s.nodeID)
-			return
-		}
-		slog.Info("Conman process exited for console", "nodeID", s.nodeID)
-
-		// Wait before reconnecting to prevent tight loop
-		select {
-		case <-time.After(time.Second):
-			// Continue to reconnection
-		case <-ctx.Done():
-			slog.Info("Session closing during reconnect delay, stopping monitor for console", "nodeID", s.nodeID)
-			return
-		}
-
-		// Check if the node still exists (might have been updated/changed)
-		if !nodes.IsCurrentNode(s.nodeID) {
-			slog.Info("Node no longer exists, closing session", "nodeID", s.nodeID)
-			s.closeWithReason(sessionCloseNormal, "node no longer exists")
-			return
-		}
-
-		slog.Info("Node still exists, attempting to reconnect", "nodeID", s.nodeID)
-		s.reconnect(ctx)
-
-	}
-}
-
-// startConmanProcess starts a new conman process with PTY
-func (s *interactiveConsoleSession) startConmanProcess(ctx context.Context) error {
-	// Check if session is closing
-	select {
-	case <-ctx.Done():
-		return fmt.Errorf("session closing, cannot start conman process: %w", ctx.Err())
-	default:
-	}
-
-	s.cmd = exec.Command("conman", s.nodeID)
-
-	ptmx, err := pty.Start(s.cmd)
-	if err != nil {
-		return fmt.Errorf("failed to start conman with PTY: %w", err)
-	}
-
-	s.ptmxMutex.Lock()
-	s.ptmx = ptmx
-	s.ptmxMutex.Unlock()
-
-	// Immediately start waiting on the process to avoid zombies
-	s.processExited = make(chan struct{})
-	go func() {
-		if err := s.cmd.Wait(); err != nil {
-			slog.Debug("Conman process wait ended with error", "nodeID", s.nodeID, "error", err)
-		}
-		// Notify monitorProcess of exit
-		close(s.processExited)
-	}()
-
-	return nil
-}
-
-// reconnect attempts to restart the conman process and reconnect streams
-// Logs errors but does not fail - monitorProcess will retry on next process exit
-func (s *interactiveConsoleSession) reconnect(ctx context.Context) {
-
-	// Notify user via WebSocket
-	reconnectMsg := fmt.Sprintf("\n[Reconnecting to %s...]\n", s.nodeID)
-	err := s.ws.Write(websocket.TextMessage, []byte(reconnectMsg))
-	if err != nil {
-		slog.Warn("WebSocket write failed, closing session", "nodeID", s.nodeID, "error", err)
-		s.closeWithReason(sessionCloseError, "websocket write failed")
-		return
-	}
-
-	// Close old PTY if it exists
-	s.ptmxMutex.Lock()
-	if s.ptmx != nil {
-		if err := s.ptmx.Close(); err != nil {
-			slog.Debug("Failed to close PTY during reconnect", "nodeID", s.nodeID, "error", err)
-		}
-	}
-	s.ptmxMutex.Unlock()
-
-	// Try to start conman again
-	slog.Info("Attempting to reconnect conman", "nodeID", s.nodeID)
-
-	if err := s.startConmanProcess(ctx); err != nil {
-		slog.Warn("Failed to start conman", "nodeID", s.nodeID, "error", err)
-		// Don't close - let monitorProcess retry
-		return
-	}
-
-	// Process started successfully
-	slog.Info("Successfully started conman for console", "nodeID", s.nodeID)
-
-	// Restart output streaming
-	// The console output itself will indicate when we're truly connected
-	// Track this new goroutine in the main WaitGroup
-	s.wg.Add(1)
-	go s.streamOutput(ctx)
-	// Note: streamInput is already running and will continue to work with the new PTY
-}
-
-// isEIO checks if an error is an I/O error (EIO)
-// This happens when reading from a PTY after the process has been killed
-func isEIO(err error) bool {
-	var errno syscall.Errno
-	if errors.As(err, &errno) {
-		return errno == syscall.EIO
-	}
-
-	return false
-}
-
-// waitForPTYReadable waits until the PTY file descriptor is readable or timeout occurs
-func waitForPTYReadable(fd int, timeout time.Duration) (bool, error) {
-	var readSet unix.FdSet
-	readSet.Zero()
-	readSet.Set(fd)
-
-	tv := unix.NsecToTimeval(timeout.Nanoseconds())
-	n, err := unix.Select(fd+1, &readSet, nil, nil, &tv)
-	if err != nil {
-		if errors.Is(err, syscall.EINTR) {
-			return false, nil
-		}
-		return false, err
-	}
-
-	return n > 0, nil
-}
-
-// streamOutput reads from PTY and writes to WebSocket
+// streamOutput reads console output from the backend and writes it to the WebSocket.
 func (s *interactiveConsoleSession) streamOutput(ctx context.Context) {
 	defer s.wg.Done()
 
-	buf := make([]byte, 4096)
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-s.ws.Done():
 			return
-		default:
-		}
-
-		s.ptmxMutex.RLock()
-		ptmx := s.ptmx
-		if ptmx == nil {
-			s.ptmxMutex.RUnlock()
-			slog.Debug("PTY is nil, exiting streamOutput for console", "nodeID", s.nodeID)
-			return
-		}
-		fd := int(ptmx.Fd())
-
-		// Wait for PTY to be readable with timeout, to allow checking for context cancellation, otherwise Read may block indefinitely
-		ready, err := waitForPTYReadable(fd, 250*time.Millisecond)
-		if err != nil {
-			s.ptmxMutex.RUnlock()
-			slog.Error("PTY read wait failed", "nodeID", s.nodeID, "error", err)
-			return
-		}
-		if !ready {
-			s.ptmxMutex.RUnlock()
-			continue
-		}
-
-		n, err := ptmx.Read(buf)
-		s.ptmxMutex.RUnlock()
-		if err != nil {
-			// Don't log I/O errors - they're expected when the process is killed
-			if err != io.EOF && !isEIO(err) {
-				slog.Error("Error reading from PTY", "nodeID", s.nodeID, "error", err)
+		case data, ok := <-s.io.Output():
+			if !ok {
+				// Backend shut down permanently.
+				s.close()
+				return
 			}
-			// PTY closed, exit gracefully without calling close() (close() already closed PTY)
-			return
-		}
 
-		if n > 0 {
-			slog.Debug("PTY read", "nodeID", s.nodeID, "bytes", n, "data", string(buf[:n]))
-
-			// Apply rate limiting (convert bytes to KB, rounded up)
-			kb := uint16((n + 1023) / 1024)
+			// Apply rate limiting.
+			kb := uint16((len(data) + 1023) / 1024)
 			for !s.rateLimiter.Pour(kb) {
-				slog.Debug("Rate limit reached, waiting for capacity", "nodeID", s.nodeID)
-				time.Sleep(100 * time.Millisecond) // Wait for bucket to drain
+				select {
+				case <-ctx.Done():
+					return
+				case <-s.ws.Done():
+					return
+				default:
+					time.Sleep(100 * time.Millisecond) // Wait for bucket to drain
+				}
 			}
 
-			err := s.ws.Write(websocket.BinaryMessage, buf[:n])
-			if err != nil {
+			if err := s.ws.Write(websocket.BinaryMessage, data); err != nil {
 				// WebSocket closed/cancelled, exit gracefully
-				slog.Info("WebSocket write failed", "nodeID", s.nodeID, "error", err)
+				slog.Info("WebSocket write failed, closing session", "nodeID", s.nodeID, "error", err)
 				return
 			}
 		}
 	}
 }
 
-// streamInput reads from WebSocket and writes to PTY
+// streamInput reads from the WebSocket and writes user input to the console backend.
 func (s *interactiveConsoleSession) streamInput(ctx context.Context) {
 	defer s.wg.Done()
 
@@ -354,31 +146,25 @@ func (s *interactiveConsoleSession) streamInput(ctx context.Context) {
 		messageType, message, err := s.ws.Read()
 		if err != nil {
 			// Check if it's an unexpected close (not normal, going away, or abnormal)
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
-				slog.Warn("WebSocket unexpected close error", "nodeID", s.nodeID, "error", err)
+			if websocket.IsUnexpectedCloseError(err,
+				websocket.CloseNormalClosure,
+				websocket.CloseGoingAway,
+				websocket.CloseAbnormalClosure,
+			) {
+				slog.Warn("WebSocket unexpected close", "nodeID", s.nodeID, "error", err)
 				s.closeWithReason(sessionCloseError, "websocket read failed")
 			} else {
-				slog.Info("WebSocket closed normally for console", "nodeID", s.nodeID)
+				slog.Info("WebSocket closed normally", "nodeID", s.nodeID)
 				s.close()
 			}
 			return
 		}
 
 		if messageType == websocket.TextMessage || messageType == websocket.BinaryMessage {
-			// Write user input to PTY
-			// Hold RLock during the entire write to prevent reconnect() from swapping PTY
-			s.ptmxMutex.RLock()
-			if s.ptmx == nil {
-				s.ptmxMutex.RUnlock()
-				slog.Debug("PTY is nil, skipping input for console", "nodeID", s.nodeID)
-				continue
-			}
-
-			_, err := s.ptmx.Write(message)
-			s.ptmxMutex.RUnlock()
-
-			if err != nil {
-				slog.Error("Failed to write to PTY", "nodeID", s.nodeID, "error", err)
+			// Both backends return len(p), nil when disconnected (silent drop),
+			// so write errors here indicate a genuine problem worth logging.
+			if _, err := s.io.Write(message); err != nil {
+				slog.Error("Failed to write to console backend", "nodeID", s.nodeID, "error", err)
 				s.closeWithReason(sessionCloseError, "failed to write to console")
 				return
 			}
@@ -386,31 +172,13 @@ func (s *interactiveConsoleSession) streamInput(ctx context.Context) {
 	}
 }
 
-// Start begins the console session by launching all goroutines and waiting for completion
-func (s *interactiveConsoleSession) Start(ctx context.Context) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
-	sessionCtx, cancel := context.WithCancel(ctx)
+// Start launches the session goroutines and blocks until both exit.
+func (s *interactiveConsoleSession) Start() {
+	sessionCtx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
 
 	// Start WebSocket session
 	s.ws.Start()
-
-	// Start initial conman process with PTY
-	if err := s.startConmanProcess(sessionCtx); err != nil {
-		slog.Error("Failed to start conman with PTY", "nodeID", s.nodeID, "error", err)
-		err = s.ws.Write(websocket.TextMessage, []byte("Error: Failed to start conman with PTY"))
-		if err != nil {
-			slog.Warn("Failed to send error message via WebSocket", "nodeID", s.nodeID, "error", err)
-		}
-		s.closeWithReason(sessionCloseError, "failed to connect to console")
-		return
-	}
-
-	// Monitor process exit for reconnection attempts
-	go s.monitorProcess(sessionCtx)
 
 	// Start I/O goroutines
 	s.wg.Add(2)
@@ -421,8 +189,9 @@ func (s *interactiveConsoleSession) Start(ctx context.Context) {
 	s.wg.Wait()
 }
 
-func newInteractiveConsoleSession(nodeID string, conn *websocket.Conn) *interactiveConsoleSession {
+func newInteractiveConsoleSession(nodeID string, conn *websocket.Conn, cio consoleIO) *interactiveConsoleSession {
 	session := &interactiveConsoleSession{
+		io:          cio,
 		nodeID:      nodeID,
 		rateLimiter: ratelimiter.NewLeakyBucket(rateLimitBurstKB, rateLimitInterval),
 	}
@@ -432,7 +201,7 @@ func newInteractiveConsoleSession(nodeID string, conn *websocket.Conn) *interact
 	return session
 }
 
-func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, r *http.Request) {
+func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, r *http.Request, sshMgr *ssh.SSHConsoleManager) {
 	// Make sure the request is cleaned up
 	defer drainAndCloseRequestBody(r)
 
@@ -443,10 +212,12 @@ func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, 
 	}
 
 	// Make sure we are monitoring a valid node
-	if exists := nodes.IsCurrentNode(nodeID); !exists {
-		http.Error(w, "Node doesn't exists", http.StatusNotFound)
+	node := nodes.CurrentNodes()[nodeID]
+	if node == nil {
+		http.Error(w, "Node doesn't exist", http.StatusNotFound)
 		return
 	}
+	useSSH := node.IsSSH()
 
 	if ok := sessions.reserve(nodeID); !ok {
 		http.Error(w, fmt.Sprintf("Console %s is already in use", nodeID), http.StatusConflict)
@@ -454,7 +225,7 @@ func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, 
 	}
 	defer sessions.release(nodeID)
 
-	slog.Info("Starting interactive console session", "nodeID", nodeID)
+	slog.Info("Starting interactive console session", "nodeID", nodeID, "backend", map[bool]string{true: "ssh", false: "conman"}[useSSH])
 
 	// Upgrade HTTP connection to WebSocket
 	conn, err := upgrader.Upgrade(w, r, nil)
@@ -465,11 +236,25 @@ func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, 
 	}
 
 	// From here on, errors must be sent via WebSocket close frames
-	session := newInteractiveConsoleSession(nodeID, conn)
+	var cio consoleIO
+	if useSSH {
+		cio, err = newSSHConsoleIO(nodeID, sshMgr)
+	} else {
+		cio, err = newConmanConsoleIO(nodeID)
+	}
+	if err != nil {
+		slog.Error("Failed to create console IO backend", "nodeID", nodeID, "error", err)
+		_ = conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "failed to connect to console"))
+		_ = conn.Close()
+		return
+	}
+
+	session := newInteractiveConsoleSession(nodeID, conn, cio)
 	defer session.close() // Ensure cleanup always happens
 
 	// Start session (blocks until all goroutines complete)
-	session.Start(r.Context())
+	session.Start()
 
 	slog.Info("Interactive console session ended", "nodeID", nodeID)
 }

--- a/internal/console/router.go
+++ b/internal/console/router.go
@@ -15,6 +15,8 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/gorilla/websocket"
 	openchami_authenticator "github.com/openchami/chi-middleware/auth"
+
+	"github.com/OpenCHAMI/remote-console/internal/ssh"
 )
 
 const routePrefix = "/remote-console"
@@ -29,7 +31,7 @@ var upgrader = websocket.Upgrader{
 }
 
 // doConsole dispatches to either interactive or tail mode based on the mode query parameter
-func doConsole(consoleLogsPath string, sessions *interactiveSessions, w http.ResponseWriter, r *http.Request) {
+func doConsole(consoleLogsPath string, sessions *interactiveSessions, sshMgr *ssh.SSHConsoleManager, w http.ResponseWriter, r *http.Request) {
 	// Parse mode parameter (defaults to "interactive")
 	params := r.URL.Query()
 	mode := params.Get("mode")
@@ -41,13 +43,13 @@ func doConsole(consoleLogsPath string, sessions *interactiveSessions, w http.Res
 	case "tail":
 		doTailConsole(consoleLogsPath, w, r)
 	case "interactive":
-		doInteractiveConsole(sessions, w, r)
+		doInteractiveConsole(sessions, w, r, sshMgr)
 	default:
 		http.Error(w, fmt.Sprintf("Invalid mode parameter: %s (must be 'interactive' or 'tail')", mode), http.StatusBadRequest)
 	}
 }
 
-func SetupRoutes(consoleLogsPath string) *chi.Mux {
+func SetupRoutes(consoleLogsPath string, sshMgr *ssh.SSHConsoleManager) *chi.Mux {
 	router := chi.NewRouter()
 	interactiveSessions := newInteractiveSessions()
 
@@ -74,7 +76,7 @@ func SetupRoutes(consoleLogsPath string) *chi.Mux {
 
 			r.Get("/consoles", doConsoles)
 			r.Get("/consoles/{nodeID}", func(w http.ResponseWriter, r *http.Request) {
-				doConsole(consoleLogsPath, interactiveSessions, w, r)
+				doConsole(consoleLogsPath, interactiveSessions, sshMgr, w, r)
 			})
 		})
 	})

--- a/internal/console/ssh_backend.go
+++ b/internal/console/ssh_backend.go
@@ -1,0 +1,57 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package console
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	"github.com/OpenCHAMI/remote-console/internal/ssh"
+)
+
+// clientIDCounter generates unique client IDs within a process.
+var clientIDCounter atomic.Uint64
+
+func generateClientID() string {
+	return strconv.FormatUint(clientIDCounter.Add(1), 10)
+}
+
+// sshConsoleIO implements consoleIO backed by an SSHConsoleNode attachment.
+type sshConsoleIO struct {
+	nodeID    string
+	clientID  string
+	out       chan []byte
+	manager   *ssh.SSHConsoleManager
+	closeOnce sync.Once
+}
+
+func newSSHConsoleIO(nodeID string, manager *ssh.SSHConsoleManager) (*sshConsoleIO, error) {
+	clientID := generateClientID()
+	ch, err := manager.Attach(nodeID, clientID)
+	if err != nil {
+		return nil, fmt.Errorf("attach SSH console %s: %w", nodeID, err)
+	}
+	return &sshConsoleIO{
+		nodeID:   nodeID,
+		clientID: clientID,
+		out:      ch,
+		manager:  manager,
+	}, nil
+}
+
+func (s *sshConsoleIO) Output() <-chan []byte { return s.out }
+
+func (s *sshConsoleIO) Write(p []byte) (int, error) {
+	return s.manager.Write(s.nodeID, p)
+}
+
+func (s *sshConsoleIO) Close() error {
+	s.closeOnce.Do(func() {
+		s.manager.Detach(s.nodeID, s.clientID)
+	})
+	return nil
+}


### PR DESCRIPTION
Introduce a shared console backend interface, preserve ConMan for IPMI nodes, and wire SSH nodes through the in-process manager.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>