### PR TITLE
test(console): cover in-process SSH consoles

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -18,4 +18,4 @@ jobs:
           go build -o remote-console ./cmd/remote-console
       - name: Run integration tests
         run: |
-          go test ./test -timeout 20m ./test
+          go test ./test -timeout 30m ./test

--- a/test/containers.go
+++ b/test/containers.go
@@ -508,7 +508,7 @@ func startRemoteConsoleWithEnv(ctx context.Context, envOverrides map[string]stri
 			"RCS_CREDS_MONITOR_INTERVAL":             "10",
 			"RCS_CREDS_SECURE_STORAGE_SSH_KEYS_PATH": "hms-creds/bmc-console-keys",
 			"RCS_CONMAN_PID_FILE_PATH":               "/app/remote-console.pid",
-			"RCS_CONMAN_LOGS_PATH":                   "/tmp",
+			"RCS_CONSOLE_LOGS_BASE_PATH":             "/tmp",
 			// Log rotation settings for testing
 			"RCS_LOG_ROTATE_CHECK_FREQUENCY": "5",  // Check every 5 seconds
 			"RCS_CONSOLE_LOGS_FILE_SIZE":     "5M", // Small size to trigger rotation easily

--- a/test/credentials_test.go
+++ b/test/credentials_test.go
@@ -54,8 +54,8 @@ func (s *IntegrationTestSuite) TestConsoleCredentialRefresh() {
 	s.T().Log("Waiting for credential monitor to detect change...")
 	time.Sleep(15 * time.Second)
 
-	// SSH returns "Permission denied, please try again." when password auth fails.
-	authOutput, err := s.readWebSocketUntil(wsConn, "Permission denied", 2*time.Minute)
+	// The Go SSH backend broadcasts a connect-failed marker when authentication fails.
+	authOutput, err := s.readWebSocketUntil(wsConn, fmt.Sprintf("[Console %s connect failed:", nodeID), 2*time.Minute)
 	s.Require().NoError(err, "expected authentication error after credentials were set incorrectly")
 	s.T().Logf("Observed auth error in console output: %s", authOutput)
 
@@ -67,7 +67,7 @@ func (s *IntegrationTestSuite) TestConsoleCredentialRefresh() {
 	s.T().Log("Waiting for credential monitor to detect restored credentials...")
 	time.Sleep(15 * time.Second)
 
-	reconnectMarker := fmt.Sprintf("<ConMan> Connection to console [%s] opened", nodeID)
+	reconnectMarker := fmt.Sprintf("[Console %s connected at", nodeID)
 	reconnectOutput, err := s.readWebSocketUntil(wsConn, reconnectMarker, 2*time.Minute)
 	s.Require().NoError(err, "expected conman to reconnect after credentials were restored")
 	s.T().Logf("Observed reconnection marker in console output: %s", reconnectOutput)

--- a/test/interactive_test.go
+++ b/test/interactive_test.go
@@ -212,9 +212,123 @@ func (s *IntegrationTestSuite) TestConsoleInteractiveReconnect() {
 	// Give the console a moment to stabilize
 	time.Sleep(2 * time.Second)
 
-	// Add a new node to trigger conmand restart
+	// Stop the SSH container to trigger a disconnection
+	s.T().Log("Stopping SSH container to trigger disconnection")
+	stopTimeout := 10 * time.Second
+	s.Require().NoError(s.containers["ssh-password"].Stop(context.Background(), &stopTimeout))
+
+	// Verify disconnect message appears
+	disconnectMsg := fmt.Sprintf("[Console %s disconnected at", existingNodeID)
+	output, err := s.readWebSocketUntil(wsConn, disconnectMsg, 2*time.Minute)
+	s.Require().NoError(err, "Expected disconnect message")
+	s.Require().Contains(output, disconnectMsg, "Expected disconnect message in output")
+	s.T().Logf("Saw disconnect message: %s", output)
+
+	// Restart the SSH container so the node can reconnect
+	s.T().Log("Starting SSH container to allow reconnection")
+	s.Require().NoError(s.containers["ssh-password"].Start(context.Background()))
+
+	// Wait for reconnection banner
+	connectedMsg := fmt.Sprintf("[Console %s connected at", existingNodeID)
+	output, err = s.readWebSocketUntil(wsConn, connectedMsg, 2*time.Minute)
+	s.Require().NoError(err, "Expected connected message after reconnection")
+	s.Require().Contains(output, connectedMsg, "Expected connected message in output")
+	s.T().Logf("Saw connected message: %s", output)
+
+	// Wait for console prompt to appear after reconnection
+	s.T().Log("Waiting for console prompt after reconnection")
+	_, err = s.waitForConsolePrompt(wsConn, ":~$ ", promptTimeout)
+	s.Require().NoError(err, "Expected console prompt after reconnection")
+	s.T().Log("Console prompt received after reconnection")
+
+	// Rerun hostname command to verify reconnection worked
+	s.T().Log("Running hostname command after reconnection")
+	err = wsConn.WriteMessage(websocket.TextMessage, []byte("hostname\r"))
+	s.Require().NoError(err, "Error sending hostname command after reconnect")
+
+	hostnameOutput2, err := s.readWebSocketUntil(wsConn, expectedHostLine, promptTimeout)
+	s.Require().NoError(err, "Expected hostname output after reconnection")
+	s.Require().Contains(hostnameOutput2, expectedHostLine, "Expected hostname in output after reconnection")
+	s.T().Logf("Hostname output after reconnection: %s", hostnameOutput2)
+
+	s.T().Log("Reconnection test completed successfully")
+}
+
+func (s *IntegrationTestSuite) TestConsoleInteractiveConmanReconnect() {
+	console := consoleFixtures["ipmi"]
+	nodeID := console.nodeID
+	promptTimeout := 90 * time.Second
+
+	wsConn, resp, err := s.connectInteractiveConsole(nodeID, console.prompt, promptTimeout)
+	s.Require().NoError(err)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			s.T().Logf("Warning: failed to close response body: %v", err)
+		}
+		if err := wsConn.Close(); err != nil {
+			s.T().Logf("Warning: failed to close websocket: %v", err)
+		}
+	}()
+
+	s.Require().NoError(wsConn.WriteMessage(websocket.TextMessage, []byte("hostname\r")))
+	expectedHostLine := nodeID + "\r\n"
+	output, err := s.readWebSocketUntil(wsConn, expectedHostLine, promptTimeout)
+	s.Require().NoError(err, "Expected hostname output before reconnect")
+	s.Require().Contains(output, expectedHostLine)
+
+	remoteConsole, ok := s.containers["remote-console"]
+	s.Require().True(ok, "remote-console container should exist")
+
+	exitCode, _, err := remoteConsole.Exec(context.Background(), []string{"pkill", "-TERM", "-x", "conman"})
+	s.Require().NoError(err, "Failed to stop conman client")
+	s.Require().Equal(0, exitCode, "No conman client was stopped")
+
+	reconnectMsg := fmt.Sprintf("[Reconnecting to %s...]", nodeID)
+	output, err = s.readWebSocketUntil(wsConn, reconnectMsg, promptTimeout)
+	s.Require().NoError(err, "Expected ConMan reconnect message")
+	s.Require().Contains(output, reconnectMsg)
+
+	_, err = s.waitForConsolePrompt(wsConn, console.prompt, promptTimeout)
+	s.Require().NoError(err, "Expected console prompt after reconnect")
+
+	s.Require().NoError(wsConn.WriteMessage(websocket.TextMessage, []byte("hostname\r")))
+	output, err = s.readWebSocketUntil(wsConn, expectedHostLine, promptTimeout)
+	s.Require().NoError(err, "Expected hostname output after reconnect")
+	s.Require().Contains(output, expectedHostLine)
+}
+
+func (s *IntegrationTestSuite) TestConsoleInteractiveNewNodeNoDisrupt() {
+	// Verify that adding a new SSH node does not disrupt an existing interactive session.
+	// Previously (conman era) adding a node caused conmand to restart, which briefly
+	// disconnected all existing consoles. With the Go SSH backend each node runs
+	// independently, so existing sessions must be unaffected.
+	console := consoleFixtures["ssh-password"]
+	existingNodeID := console.nodeID
+	promptTimeout := 90 * time.Second
+
+	wsConn, resp, err := s.connectInteractiveConsole(existingNodeID, console.prompt, promptTimeout)
+	s.Require().NoError(err)
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			s.T().Logf("Warning: failed to close response body: %v", err)
+		}
+		if err := wsConn.Close(); err != nil {
+			s.T().Logf("Warning: failed to close websocket: %v", err)
+		}
+	}()
+
+	// Verify the existing console is working before adding a new node.
+	err = wsConn.WriteMessage(websocket.TextMessage, []byte("hostname\r"))
+	s.Require().NoError(err, "Error sending hostname command")
+	expectedHostLine := existingNodeID + "\r\n"
+	hostnameOutput, err := s.readWebSocketUntil(wsConn, expectedHostLine, promptTimeout)
+	s.Require().NoError(err, "Expected hostname output before new node added")
+	s.Require().Contains(hostnameOutput, expectedHostLine)
+	s.T().Logf("Initial hostname output: %s", hostnameOutput)
+
+	// Add a new SSH node.
 	newNodeID := "x0c0s10b0"
-	s.T().Logf("Adding new node %s to trigger conmand restart", newNodeID)
+	s.T().Logf("Adding new node %s", newNodeID)
 
 	authConfig := defaultAuthConfig
 	rfContainer, err := startRedfishEmulator(context.Background(), s.rfNetwork.Name, newNodeID, "ssh", &authConfig)
@@ -247,9 +361,7 @@ func (s *IntegrationTestSuite) TestConsoleInteractiveReconnect() {
 	})
 	s.Require().NoError(err, "failed to register new Redfish endpoint")
 
-	// Clean up the Redfish endpoint at the end to avoid interfering with other tests
 	defer func() {
-		s.T().Logf("Removing Redfish endpoint %s", newNodeID)
 		smdAPIURL, err := getSMDAPIURL(context.Background(), s.containers["smd"])
 		if err != nil {
 			s.T().Errorf("Warning: failed to get SMD API URL: %v", err)
@@ -260,38 +372,20 @@ func (s *IntegrationTestSuite) TestConsoleInteractiveReconnect() {
 		}
 	}()
 
-	// Verify reconnect messages appear
-	s.T().Log("Waiting for reconnection messages")
-	reconnectingMsg := fmt.Sprintf("[Reconnecting to %s", existingNodeID)
-	output, err := s.readWebSocketUntil(wsConn, reconnectingMsg, 2*time.Minute)
-	s.Require().NoError(err, "Expected reconnecting message")
-	s.Require().Contains(output, reconnectingMsg, "Expected reconnecting message in output")
-	s.T().Logf("Saw reconnecting message: %s", output)
+	// Wait for remote-console to discover the new node.
+	s.Require().NoError(s.waitForConsoleID(newNodeID, 3*time.Minute), "remote-console did not detect new console")
+	s.T().Logf("New node %s is visible in remote-console", newNodeID)
 
-	// Wait for ConMan connection banner to confirm successful reconnection
-	conmanConnectedMsg := fmt.Sprintf("<ConMan> Connection to console [%s] opened", existingNodeID)
-	output, err = s.readWebSocketUntil(wsConn, conmanConnectedMsg, 2*time.Minute)
-	s.Require().NoError(err, "Expected ConMan connection banner")
-	s.Require().Contains(output, conmanConnectedMsg, "Expected ConMan connection banner in output")
-	s.T().Logf("Saw ConMan connection banner: %s", output)
-
-	// Wait for console prompt to appear after reconnection
-	s.T().Log("Waiting for console prompt after reconnection")
-	_, err = s.waitForConsolePrompt(wsConn, ":~$ ", promptTimeout)
-	s.Require().NoError(err, "Expected console prompt after reconnection")
-	s.T().Log("Console prompt received after reconnection")
-
-	// Rerun hostname command to verify reconnection worked
-	s.T().Log("Running hostname command after reconnection")
+	// The existing session must still be alive and functional — no disconnect markers,
+	// no reconnect banners.
 	err = wsConn.WriteMessage(websocket.TextMessage, []byte("hostname\r"))
-	s.Require().NoError(err, "Error sending hostname command after reconnect")
-
+	s.Require().NoError(err, "Error sending hostname command after new node added")
 	hostnameOutput2, err := s.readWebSocketUntil(wsConn, expectedHostLine, promptTimeout)
-	s.Require().NoError(err, "Expected hostname output after reconnection")
-	s.Require().Contains(hostnameOutput2, expectedHostLine, "Expected hostname in output after reconnection")
-	s.T().Logf("Hostname output after reconnection: %s", hostnameOutput2)
-
-	s.T().Log("Reconnection test completed successfully")
+	s.Require().NoError(err, "Expected hostname output after new node added")
+	s.Require().Contains(hostnameOutput2, expectedHostLine, "Expected hostname in output after new node added")
+	s.Require().NotContains(hostnameOutput2, fmt.Sprintf("[Console %s disconnected", existingNodeID),
+		"Existing session must not have disconnected when a new node was added")
+	s.T().Logf("Existing session still alive after new node added: %s", hostnameOutput2)
 }
 
 func (s *IntegrationTestSuite) TestConsoleInteractiveClientClose() {

--- a/test/tail_test.go
+++ b/test/tail_test.go
@@ -351,19 +351,19 @@ func (s *IntegrationTestSuite) TestConsoleTailLinesFollow() {
 }
 
 func (s *IntegrationTestSuite) TestConsoleTailEntryCommand() {
-	// Test that the entry command is executed when connecting to the console
+	// Test that the entry command is executed when connecting to the console.
+	// x0c0s0b0n0 connects to the same SSH server as the ssh-password fixture (x0c0s0b0),
+	// so we broadcast via that container's broadcast.sh the same way other SSH fixtures do.
 	console := consoleFixture{
 		name:           "ssh-entry-cmd",
 		nodeID:         "x0c0s0b0n0",
-		containerKey:   "remote-console",
+		containerKey:   "ssh-password",
 		username:       "ADMIN",
 		password:       "ADMIN",
 		readyLogMarker: "Welcome to OpenSSH Server",
 		prompt:         ":~$ ",
-		// We use 'expect' here as with the entry command there may not be a pty that
-		// broadcast.sh can write to, so we spawn conman in expect to echo a message
 		broadcastCmd: func(msg string) []string {
-			return []string{"expect", "-c", fmt.Sprintf("spawn conman x0c0s0b0n0; expect \"password:\"; expect \":~$ \"; send \"echo '%s'\\r\"; send \"&.\\r\"; expect eof", msg)}
+			return []string{"broadcast.sh", msg}
 		},
 	}
 


### PR DESCRIPTION
Adapt the end-to-end console scenarios to the SSH backend and allow the container-heavy integration suite up to 30 minutes.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>