### PR TITLE
fix(console): preserve session close behavior

### DIFF
--- a/internal/console/conman_backend_test.go
+++ b/internal/console/conman_backend_test.go
@@ -1,0 +1,197 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package console
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestConmanConsoleIOCloseIsIdempotent(t *testing.T) {
+	var cancelCalls atomic.Int32
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &conmanConsoleIO{
+		ctx: ctx,
+		cancel: func() {
+			cancelCalls.Add(1)
+			cancel()
+		},
+	}
+
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Go(func() {
+			if err := c.Close(); err != nil {
+				t.Errorf("Close: %v", err)
+			}
+		})
+	}
+	wg.Wait()
+
+	if got := cancelCalls.Load(); got != 1 {
+		t.Fatalf("cancel called %d times, want 1", got)
+	}
+
+	if _, err := c.startProcess(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("startProcess after Close returned %v, want context.Canceled", err)
+	}
+}
+
+func TestConmanProcessStopReapsChild(t *testing.T) {
+	process, err := launchPTYProcess("test", exec.Command("cat"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	process.stop()
+	process.stop()
+
+	select {
+	case <-process.done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("conman process was not reaped after shutdown")
+	}
+}
+
+func TestConmanConsoleIOReadWrite(t *testing.T) {
+	process, err := launchPTYProcess("test", exec.Command("cat"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &conmanConsoleIO{
+		nodeID:  "test",
+		process: process,
+		out:     make(chan []byte, conmanOutputBufferDepth),
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+	t.Cleanup(func() { _ = c.Close() })
+
+	readDone := make(chan struct{})
+	go func() {
+		c.streamOutput(process)
+		close(readDone)
+	}()
+
+	input := []byte("hello\n")
+	if _, err := c.Write(input); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	select {
+	case output := <-c.Output():
+		if !bytes.Contains(output, []byte("hello")) {
+			t.Fatalf("output %q does not contain input", output)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for PTY output")
+	}
+
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-readDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("PTY read did not stop after Close")
+	}
+}
+
+func TestConmanConsoleIOWriteWhileDisconnected(t *testing.T) {
+	c := &conmanConsoleIO{}
+	if _, err := c.Write([]byte("input")); !errors.Is(err, errNotConnected) {
+		t.Fatalf("Write returned %v, want errNotConnected", err)
+	}
+}
+
+func TestConmanConsoleIOCloseUnblocksWriter(t *testing.T) {
+	process, err := launchPTYProcess("test", exec.Command("sleep", "30"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &conmanConsoleIO{
+		nodeID:  "test",
+		process: process,
+		out:     make(chan []byte, conmanOutputBufferDepth),
+		ctx:     ctx,
+		cancel:  cancel,
+	}
+
+	writeDone := make(chan struct{})
+	go func() {
+		defer close(writeDone)
+		input := make([]byte, maxWebSocketMessageSize)
+		for {
+			if _, err := c.Write(input); err != nil {
+				return
+			}
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	if err := c.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case <-writeDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Close did not unblock a PTY writer")
+	}
+}
+
+func TestConmanConsoleIOReportsDroppedOutput(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	c := &conmanConsoleIO{
+		nodeID: "test",
+		out:    make(chan []byte, 1),
+		ctx:    ctx,
+	}
+
+	if !c.queueOutput([]byte("first")) || !c.queueOutput([]byte("dropped")) {
+		t.Fatal("queueOutput stopped while the context was active")
+	}
+	<-c.out
+
+	if !c.queueOutput([]byte("next")) {
+		t.Fatal("queueOutput stopped while the context was active")
+	}
+	select {
+	case output := <-c.out:
+		if !bytes.Contains(output, []byte("7 bytes of output dropped")) {
+			t.Fatalf("output %q does not report the dropped bytes", output)
+		}
+	default:
+		t.Fatal("missing dropped output notice")
+	}
+}
+
+func TestConmanReconnectBackoff(t *testing.T) {
+	if got := nextConmanBackoff(time.Second); got != 2*time.Second {
+		t.Fatalf("next backoff = %s, want 2s", got)
+	}
+	if got := nextConmanBackoff(20 * time.Second); got != conmanReconnectMax {
+		t.Fatalf("capped backoff = %s, want %s", got, conmanReconnectMax)
+	}
+
+	for range 100 {
+		got := jitterConmanBackoff(10 * time.Second)
+		if got < 5*time.Second || got > 10*time.Second {
+			t.Fatalf("jittered backoff %s is outside [5s, 10s]", got)
+		}
+	}
+}

--- a/internal/console/interactive.go
+++ b/internal/console/interactive.go
@@ -75,25 +75,23 @@ func (s *interactiveConsoleSession) close() {
 func (s *interactiveConsoleSession) closeWithReason(reason sessionCloseReason, message string) {
 	slog.Info("Closing interactive console session", "nodeID", s.nodeID)
 
-	// 1. Shut down the backend (SSH detach or PTY SIGTERM). Idempotent.
+	// Shut down the backend (SSH detach or PTY SIGTERM). Idempotent.
 	if err := s.io.Close(); err != nil {
 		slog.Debug("Error closing console IO", "nodeID", s.nodeID, "error", err)
 	}
 
-	// 2. Cancel the session context to unblock both goroutines.
+	// Cancel the session context to unblock both goroutines.
 	if s.cancel != nil {
 		s.cancel()
 	}
 
-	// 3. Send a WebSocket close frame. This causes writePump to close the
-	//    underlying TCP connection, which unblocks streamInput's ReadMessage.
+	// Send a WebSocket close frame. This causes writePump to close the
+	// underlying TCP connection, which unblocks streamInput's ReadMessage.
 	s.ws.close(reason, message)
 }
 
 // streamOutput reads console output from the backend and writes it to the WebSocket.
 func (s *interactiveConsoleSession) streamOutput(ctx context.Context) {
-	defer s.wg.Done()
-
 	for {
 		select {
 		case <-ctx.Done():
@@ -110,6 +108,7 @@ func (s *interactiveConsoleSession) streamOutput(ctx context.Context) {
 			// Apply rate limiting.
 			kb := uint16((len(data) + 1023) / 1024)
 			for !s.rateLimiter.Pour(kb) {
+				// Keep shutdown responsive while waiting for capacity.
 				select {
 				case <-ctx.Done():
 					return
@@ -131,8 +130,6 @@ func (s *interactiveConsoleSession) streamOutput(ctx context.Context) {
 
 // streamInput reads from the WebSocket and writes user input to the console backend.
 func (s *interactiveConsoleSession) streamInput(ctx context.Context) {
-	defer s.wg.Done()
-
 	for {
 		select {
 		// Check for session closure
@@ -164,9 +161,7 @@ func (s *interactiveConsoleSession) streamInput(ctx context.Context) {
 		if messageType == websocket.TextMessage || messageType == websocket.BinaryMessage {
 			if _, err := s.io.Write(message); err != nil {
 				if errors.Is(err, errNotConnected) {
-					// The backend is between connections. Discard the input and
-					// keep the client attached — it reconnects on its own, and
-					// the client sees the reconnect marker on the output stream.
+					// Drop input while the backend reconnects and keep the client attached.
 					slog.Debug("Dropped console input, backend not connected",
 						"nodeID", s.nodeID, "bytes", len(message))
 					continue
@@ -180,17 +175,24 @@ func (s *interactiveConsoleSession) streamInput(ctx context.Context) {
 }
 
 // Start launches the session goroutines and blocks until both exit.
-func (s *interactiveConsoleSession) Start() {
-	sessionCtx, cancel := context.WithCancel(context.Background())
+func (s *interactiveConsoleSession) Start(ctx context.Context) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	sessionCtx, cancel := context.WithCancel(ctx)
 	s.cancel = cancel
 
 	// Start WebSocket session
 	s.ws.Start()
 
 	// Start I/O goroutines
-	s.wg.Add(2)
-	go s.streamInput(sessionCtx)
-	go s.streamOutput(sessionCtx)
+	s.wg.Go(func() {
+		s.streamInput(sessionCtx)
+	})
+	s.wg.Go(func() {
+		s.streamOutput(sessionCtx)
+	})
 
 	// Wait for I/O goroutines to complete
 	s.wg.Wait()
@@ -247,7 +249,6 @@ func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, 
 		http.Error(w, "Node doesn't exist", http.StatusNotFound)
 		return
 	}
-	useSSH := node.IsSSH()
 
 	if ok := sessions.reserve(nodeID); !ok {
 		http.Error(w, fmt.Sprintf("Console %s is already in use", nodeID), http.StatusConflict)
@@ -255,7 +256,7 @@ func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, 
 	}
 	defer sessions.release(nodeID)
 
-	slog.Info("Starting interactive console session", "nodeID", nodeID, "backend", map[bool]string{true: "ssh", false: "conman"}[useSSH])
+	slog.Info("Starting interactive console session", "nodeID", nodeID)
 
 	// Upgrade HTTP connection to WebSocket
 	conn, err := upgrader.Upgrade(w, r, nil)
@@ -282,7 +283,7 @@ func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, 
 	defer session.close() // Ensure cleanup always happens
 
 	// Start session (blocks until all goroutines complete)
-	session.Start()
+	session.Start(r.Context())
 
 	slog.Info("Interactive console session ended", "nodeID", nodeID)
 }

--- a/internal/console/interactive_test.go
+++ b/internal/console/interactive_test.go
@@ -5,7 +5,20 @@
 package console
 
 import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
 	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+
+	"github.com/OpenCHAMI/remote-console/internal/nodes"
+	"github.com/OpenCHAMI/remote-console/internal/ssh"
 )
 
 func TestReservationExclusive(t *testing.T) {
@@ -28,4 +41,346 @@ func TestReservationExclusive(t *testing.T) {
 	if ok := sessions.reserve(nodeID); !ok {
 		t.Fatal("expected reservation after release to succeed")
 	}
+}
+
+// fakeConsoleIO records attempted and accepted writes separately.
+type fakeConsoleIO struct {
+	out chan []byte
+
+	mu        sync.Mutex
+	err       error
+	attempted []string
+	accepted  []string
+	closed    bool
+}
+
+func newFakeConsoleIO() *fakeConsoleIO {
+	return &fakeConsoleIO{out: make(chan []byte, 16)}
+}
+
+func (f *fakeConsoleIO) Output() <-chan []byte { return f.out }
+
+func (f *fakeConsoleIO) Write(p []byte) (int, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.attempted = append(f.attempted, string(p))
+	if f.err != nil {
+		return 0, f.err
+	}
+	f.accepted = append(f.accepted, string(p))
+	return len(p), nil
+}
+
+func (f *fakeConsoleIO) Close() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.closed = true
+	return nil
+}
+
+func (f *fakeConsoleIO) setErr(err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.err = err
+}
+
+func (f *fakeConsoleIO) snapshot() (attempted, accepted []string, closed bool) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.attempted...), append([]string(nil), f.accepted...), f.closed
+}
+
+// startSession mirrors the production handler shutdown behavior.
+func startSession(t *testing.T, cio consoleIO) (client *websocket.Conn, done chan struct{}) {
+	t.Helper()
+
+	done = make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		session := newInteractiveConsoleSession("test-node", conn, cio)
+		defer close(done)
+		defer session.close()
+		session.Start(r.Context())
+	}))
+	t.Cleanup(srv.Close)
+
+	client, _, err := websocket.DefaultDialer.Dial("ws"+strings.TrimPrefix(srv.URL, "http"), nil)
+	if err != nil {
+		t.Fatalf("dial console websocket: %v", err)
+	}
+	t.Cleanup(func() { _ = client.Close() })
+
+	return client, done
+}
+
+func waitFor(t *testing.T, timeout time.Duration, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if cond() {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %s", what)
+}
+
+func sendText(t *testing.T, c *websocket.Conn, s string) {
+	t.Helper()
+	if err := c.WriteMessage(websocket.TextMessage, []byte(s)); err != nil {
+		t.Fatalf("client write %q: %v", s, err)
+	}
+}
+
+func TestInteractiveSessionForwardsInput(t *testing.T) {
+	fake := newFakeConsoleIO()
+	client, _ := startSession(t, fake)
+
+	sendText(t, client, "uname -a\r")
+
+	waitFor(t, 5*time.Second, "input to reach the backend", func() bool {
+		_, accepted, _ := fake.snapshot()
+		return len(accepted) == 1 && accepted[0] == "uname -a\r"
+	})
+}
+
+func TestInteractiveSessionRejectsOversizedInput(t *testing.T) {
+	fake := newFakeConsoleIO()
+	client, done := startSession(t, fake)
+
+	input := make([]byte, maxWebSocketMessageSize+1)
+	if err := client.WriteMessage(websocket.BinaryMessage, input); err != nil {
+		t.Fatalf("client write: %v", err)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("session did not close after oversized input")
+	}
+
+	attempted, _, _ := fake.snapshot()
+	if len(attempted) != 0 {
+		t.Fatalf("oversized input reached the backend in %d writes", len(attempted))
+	}
+}
+
+// A temporary disconnect drops input without ending the session.
+func TestInteractiveSessionSurvivesNotConnected(t *testing.T) {
+	fake := newFakeConsoleIO()
+	fake.setErr(errNotConnected)
+	client, done := startSession(t, fake)
+
+	sendText(t, client, "lost\r")
+	waitFor(t, 5*time.Second, "the dropped input to be attempted", func() bool {
+		attempted, _, _ := fake.snapshot()
+		return len(attempted) == 1
+	})
+
+	select {
+	case <-done:
+		t.Fatal("session ended when the backend was merely disconnected")
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	fake.setErr(nil)
+	sendText(t, client, "recovered\r")
+
+	waitFor(t, 5*time.Second, "input after the backend reconnected", func() bool {
+		_, accepted, _ := fake.snapshot()
+		return len(accepted) == 1 && accepted[0] == "recovered\r"
+	})
+
+	attempted, accepted, _ := fake.snapshot()
+	if len(attempted) != 2 {
+		t.Errorf("backend saw %d write attempts, want 2: %q", len(attempted), attempted)
+	}
+	for _, got := range accepted {
+		if got == "lost\r" {
+			t.Error("input written while disconnected was reported as accepted")
+		}
+	}
+}
+
+// A permanent write error closes the client with the original reason.
+func TestInteractiveSessionClosesOnWriteError(t *testing.T) {
+	fake := newFakeConsoleIO()
+	fake.setErr(errors.New("console backend exploded"))
+	client, done := startSession(t, fake)
+
+	sendText(t, client, "anything\r")
+
+	_ = client.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, _, err := client.ReadMessage()
+	if err == nil {
+		t.Fatal("client read succeeded; the session did not close on a backend write error")
+	}
+	var closeErr *websocket.CloseError
+	if !errors.As(err, &closeErr) {
+		t.Fatalf("client saw %v, want a websocket close frame", err)
+	}
+	if closeErr.Code != websocket.CloseInternalServerErr {
+		t.Errorf("close code = %d (%q), want %d because the failure was relabelled",
+			closeErr.Code, closeErr.Text, websocket.CloseInternalServerErr)
+	}
+	if closeErr.Text != "failed to write to console" {
+		t.Errorf("close reason = %q, want %q", closeErr.Text, "failed to write to console")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("session goroutines did not exit after the backend write error")
+	}
+
+	if _, _, closed := fake.snapshot(); !closed {
+		t.Error("backend was not closed when the session ended")
+	}
+}
+
+func deadTCPPort(t *testing.T) int {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return port
+}
+
+// Wait for node goroutines before temporary log cleanup.
+func newTestSSHManager(t *testing.T, logsDir string) (*ssh.SSHConsoleManager, context.Context) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	mgr := ssh.NewSSHConsoleManager(ssh.DefaultSSHConfig(), "", logsDir)
+	t.Cleanup(func() {
+		cancel()
+		mgr.Wait()
+	})
+	return mgr, ctx
+}
+
+// Temporary SSH disconnects use the package sentinel and retain the SSH cause.
+func TestSSHBackendTranslatesNotConnected(t *testing.T) {
+	const nodeID = "x0c0s1b0n0"
+
+	mgr, ctx := newTestSSHManager(t, t.TempDir())
+	node := &nodes.NodeConsoleInfo{
+		ID:             nodeID,
+		ConnectionType: nodes.SSH,
+		ConnectionHost: "127.0.0.1",
+		ConnectionPort: deadTCPPort(t),
+	}
+	if err := mgr.UpdateNodes(ctx, map[string]*nodes.NodeConsoleInfo{nodeID: node}); err != nil {
+		t.Fatal(err)
+	}
+
+	cio, err := newSSHConsoleIO(nodeID, mgr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = cio.Close() })
+
+	// A registered node without a connection models a reconnect in progress.
+	_, err = cio.Write([]byte("keystroke"))
+	if !errors.Is(err, errNotConnected) {
+		t.Fatalf("Write to a disconnected SSH node returned %v, want errNotConnected", err)
+	}
+	// The wrapped SSH cause remains available to callers.
+	if !errors.Is(err, ssh.ErrNotConnected) {
+		t.Errorf("Write returned %v; the ssh cause was dropped instead of wrapped", err)
+	}
+
+	// An unmanaged node is a permanent failure.
+	absent := &sshConsoleIO{nodeID: "no-such-node", manager: mgr}
+	if _, err := absent.Write([]byte("keystroke")); err == nil {
+		t.Error("Write to an unmanaged node succeeded")
+	} else if errors.Is(err, errNotConnected) {
+		t.Error("Write to an unmanaged node reported errNotConnected; the session would keep the client attached to a console that does not exist")
+	}
+}
+
+// Deferred cleanup must not replace the original close reason.
+func TestWebSocketCloseReasonFirstWins(t *testing.T) {
+	ws := newWebSocketSession(nil, "test")
+
+	ws.close(sessionCloseError, "failed to write to console")
+	ws.close(sessionCloseNormal, "")
+
+	ws.closeMutex.Lock()
+	code, reason := ws.closeCode, ws.closeReason
+	ws.closeMutex.Unlock()
+
+	if code != websocket.CloseInternalServerErr {
+		t.Errorf("close code = %d, want %d: deferred cleanup relabelled a failure as a clean exit",
+			code, websocket.CloseInternalServerErr)
+	}
+	if reason != "failed to write to console" {
+		t.Errorf("close reason = %q, want the original failure text", reason)
+	}
+}
+
+// Connection types select the expected backend.
+func TestNewConsoleIODispatch(t *testing.T) {
+	const nodeID = "x0c0s0b0n0"
+
+	mgr, ctx := newTestSSHManager(t, t.TempDir())
+	sshNode := &nodes.NodeConsoleInfo{
+		ID:             nodeID,
+		ConnectionType: nodes.SSH,
+		ConnectionHost: "127.0.0.1",
+		ConnectionPort: 1,
+	}
+	if err := mgr.UpdateNodes(ctx, map[string]*nodes.NodeConsoleInfo{nodeID: sshNode}); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("ssh node uses the ssh manager", func(t *testing.T) {
+		cio, err := newConsoleIO(sshNode, mgr)
+		if err != nil {
+			t.Fatalf("newConsoleIO for an SSH node: %v", err)
+		}
+		t.Cleanup(func() { _ = cio.Close() })
+		if _, ok := cio.(*sshConsoleIO); !ok {
+			t.Fatalf("SSH node got a %T backend, want *sshConsoleIO", cio)
+		}
+	})
+
+	t.Run("ipmi node uses conman", func(t *testing.T) {
+		ipmiNode := &nodes.NodeConsoleInfo{
+			ID:             nodeID,
+			ConnectionType: nodes.IPMI,
+			ConnectionHost: "127.0.0.1",
+		}
+		// This node exists only in the SSH manager, so ConMan must reject it.
+		cio, err := newConsoleIO(ipmiNode, mgr)
+		if err == nil {
+			_ = cio.Close()
+			t.Fatalf("IPMI node got a %T backend; it was routed to the SSH manager", cio)
+		}
+		if cio != nil {
+			t.Errorf("newConsoleIO returned both a backend (%T) and an error", cio)
+		}
+	})
+
+	t.Run("unsupported node is rejected", func(t *testing.T) {
+		node := &nodes.NodeConsoleInfo{
+			ID:             nodeID,
+			ConnectionType: "telnet",
+		}
+		cio, err := newConsoleIO(node, mgr)
+		if err == nil {
+			t.Fatalf("unsupported node got a %T backend", cio)
+		}
+		if cio != nil {
+			t.Errorf("newConsoleIO returned both a backend (%T) and an error", cio)
+		}
+	})
 }

--- a/internal/console/websocket.go
+++ b/internal/console/websocket.go
@@ -18,6 +18,8 @@ const (
 	writeWait  = 10 * time.Second
 	pongWait   = 60 * time.Second
 	pingPeriod = 30 * time.Second
+	// This allows large terminal pastes without accepting unbounded input.
+	maxWebSocketMessageSize = 64 * 1024
 )
 
 type webSockMessage struct {
@@ -40,12 +42,16 @@ type webSocketSession struct {
 	ctx         context.Context // cancelled when the session is closed
 	cancel      context.CancelFunc
 	closeMutex  sync.Mutex
+	closeSet    bool // guards against a later close overwriting the first reason
 	closeCode   int
 	closeReason string
 }
 
 func newWebSocketSession(conn *websocket.Conn, name string) *webSocketSession {
 	ctx, cancel := context.WithCancel(context.Background())
+	if conn != nil {
+		conn.SetReadLimit(maxWebSocketMessageSize)
+	}
 	return &webSocketSession{
 		conn:   conn,
 		send:   make(chan webSockMessage, 64),
@@ -88,11 +94,19 @@ func (ws *webSocketSession) Write(messageType int, data []byte) error {
 	}
 }
 
+// close records why the session is ending and unblocks writePump, which sends
+// the close frame.
+//
+// The first reason wins. A specific error may close the session before deferred
+// cleanup closes it again. Letting the last caller win would relabel the error
+// as a normal closure.
 func (ws *webSocketSession) close(reason sessionCloseReason, message string) {
 	ws.closeMutex.Lock()
-	code := mapCloseReason(reason)
-	ws.closeCode = code
-	ws.closeReason = message
+	if !ws.closeSet {
+		ws.closeSet = true
+		ws.closeCode = mapCloseReason(reason)
+		ws.closeReason = message
+	}
 	ws.closeMutex.Unlock()
 	ws.cancel()
 }

--- a/internal/ssh/concurrent_test.go
+++ b/internal/ssh/concurrent_test.go
@@ -79,6 +79,7 @@ func TestSSHConsoleManagerConcurrent(t *testing.T) {
 	cfg.ReconnectMaxInterval = 500 * time.Millisecond
 
 	manager := ssh.NewSSHConsoleManager(cfg, "", t.TempDir())
+	waitOnCleanup(t, manager)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -36,6 +36,11 @@ type SSHConsoleManager struct {
 	nodes   map[string]*SSHConsoleNode
 	// cancels maps nodeID to the cancel func for that node's Run goroutine.
 	cancels map[string]context.CancelFunc
+
+	// running tracks the live Run goroutines so callers can tell when the last
+	// one has released its log file. Cancelling a node's context only asks it
+	// to stop; the goroutine may still be opening or writing its log for a
+	// short while afterwards. See Wait.
 	running sync.WaitGroup
 }
 
@@ -52,12 +57,6 @@ func NewSSHConsoleManager(cfg SSHConfig, keyPath, logsPath string) *SSHConsoleMa
 		nodes:    make(map[string]*SSHConsoleNode),
 		cancels:  make(map[string]context.CancelFunc),
 	}
-}
-
-// Wait blocks until all console goroutines have stopped. The caller must first
-// cancel the context passed to UpdateNodes or remove every managed node.
-func (m *SSHConsoleManager) Wait() {
-	m.running.Wait()
 }
 
 // logPath returns the log file path for a node.
@@ -187,6 +186,12 @@ func (m *SSHConsoleManager) startNode(ctx context.Context, nodeID string, info *
 		defer m.running.Done()
 		node.Run(nodeCtx)
 	}()
+}
+
+// Wait blocks until all console goroutines have stopped. The caller must first
+// cancel the context passed to UpdateNodes or remove every managed node.
+func (m *SSHConsoleManager) Wait() {
+	m.running.Wait()
 }
 
 // UpdateCredentials updates credentials for nodes whose passwords have changed.

--- a/internal/ssh/scale_test.go
+++ b/internal/ssh/scale_test.go
@@ -74,6 +74,7 @@ func TestSSHConsoleManagerScale(t *testing.T) {
 	cfg.ReconnectMaxInterval = 2 * time.Second
 
 	manager := ssh.NewSSHConsoleManager(cfg, "", t.TempDir())
+	waitOnCleanup(t, manager)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/internal/ssh/server_test.go
+++ b/internal/ssh/server_test.go
@@ -255,6 +255,10 @@ func makePasswordsWith(ids []string, password string) map[string]compcredentials
 
 // newManager creates an SSHConsoleManager with fast reconnect intervals
 // suitable for tests.
+//
+// Pass logsDir as t.TempDir() at the call site — see waitOnCleanup for why the
+// order matters. Callers must cancel the context they hand to
+// UpdateNodesAndCredentials/UpdateNodes with defer, which runs before this cleanup.
 func newManager(t *testing.T, logsDir string) *ssh.SSHConsoleManager {
 	t.Helper()
 	cfg := ssh.DefaultSSHConfig()
@@ -262,8 +266,25 @@ func newManager(t *testing.T, logsDir string) *ssh.SSHConsoleManager {
 	cfg.ReconnectMinInterval = 250 * time.Millisecond
 	cfg.ReconnectMaxInterval = 1 * time.Second
 	manager := ssh.NewSSHConsoleManager(cfg, "", logsDir)
-	t.Cleanup(manager.Wait)
+	waitOnCleanup(t, manager)
 	return manager
+}
+
+// waitOnCleanup makes a test wait for the manager's node goroutines before it
+// finishes.
+//
+// A node opens its log file as the first thing Run does, and the manager only
+// ever asks nodes to stop. A test that hands t.TempDir() to a manager and
+// returns without waiting races its own cleanup: RemoveAll empties the
+// directory, a node goroutine gets scheduled and recreates the log file, and
+// the final rmdir fails with "directory not empty".
+//
+// Cleanups run last-in-first-out, so as long as the caller obtained logsDir
+// from t.TempDir() before reaching here, the wait happens first and the
+// directory is empty when it is removed.
+func waitOnCleanup(t *testing.T, manager *ssh.SSHConsoleManager) {
+	t.Helper()
+	t.Cleanup(manager.Wait)
 }
 
 // waitForMarker reads from ch until the accumulated output contains marker or


### PR DESCRIPTION
Keep the first WebSocket close reason and test backend dispatch and
transient reconnect handling. Track console goroutines so shutdown and
tests can wait for resource cleanup.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>