### PR TITLE
refactor(console): encapsulate ConMan console I/O

### DIFF
--- a/internal/console/conman_backend.go
+++ b/internal/console/conman_backend.go
@@ -1,0 +1,241 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package console
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"sync"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/OpenCHAMI/remote-console/internal/nodes"
+	"github.com/creack/pty"
+)
+
+// conmanConsoleIO implements consoleIO for IPMI nodes managed by conman.
+// It runs a goroutine that keeps a conman process alive, reconnecting automatically.
+type conmanConsoleIO struct {
+	nodeID string
+
+	mu   sync.Mutex
+	cmd  *exec.Cmd
+	ptmx *os.File
+
+	out    chan []byte
+	ctx    context.Context
+	cancel context.CancelFunc
+
+	closeOnce sync.Once
+}
+
+// newConmanConsoleIO creates and starts a conmanConsoleIO for nodeID.
+func newConmanConsoleIO(nodeID string) (*conmanConsoleIO, error) {
+	if !nodes.IsCurrentNode(nodeID) {
+		return nil, fmt.Errorf("node %s is not a current node", nodeID)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &conmanConsoleIO{
+		nodeID: nodeID,
+		out:    make(chan []byte, 256),
+		ctx:    ctx,
+		cancel: cancel,
+	}
+
+	go c.run()
+	return c, nil
+}
+
+// run is the internal goroutine that manages the conman process lifecycle.
+func (c *conmanConsoleIO) run() {
+	defer close(c.out)
+
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		default:
+		}
+
+		if err := c.startProcess(); err != nil {
+			slog.Error("Failed to start conman process", "nodeID", c.nodeID, "error", err)
+			select {
+			case <-time.After(time.Second):
+			case <-c.ctx.Done():
+				return
+			}
+			continue
+		}
+
+		c.readLoop()
+
+		// Process exited. Clean up.
+		c.mu.Lock()
+		c.ptmx = nil
+		c.cmd = nil
+		c.mu.Unlock()
+
+		// Notify the client and wait before reconnecting.
+		reconnectMsg := fmt.Sprintf("\n[Reconnecting to %s...]\n", c.nodeID)
+		select {
+		case c.out <- []byte(reconnectMsg):
+		case <-c.ctx.Done():
+			return
+		}
+
+		select {
+		case <-time.After(time.Second):
+		case <-c.ctx.Done():
+			return
+		}
+
+		if !nodes.IsCurrentNode(c.nodeID) {
+			slog.Info("Node no longer in inventory, stopping conman backend", "nodeID", c.nodeID)
+			return
+		}
+	}
+}
+
+// startProcess launches a new conman process with a PTY.
+func (c *conmanConsoleIO) startProcess() error {
+	select {
+	case <-c.ctx.Done():
+		return fmt.Errorf("context cancelled")
+	default:
+	}
+
+	cmd := exec.Command("conman", c.nodeID)
+	ptmx, err := pty.Start(cmd)
+	if err != nil {
+		return fmt.Errorf("pty.Start conman: %w", err)
+	}
+
+	c.mu.Lock()
+	c.cmd = cmd
+	c.ptmx = ptmx
+	c.mu.Unlock()
+
+	// Reap the child process to prevent zombies.
+	go func() {
+		if err := cmd.Wait(); err != nil {
+			slog.Debug("conman process exited", "nodeID", c.nodeID, "error", err)
+		}
+	}()
+
+	return nil
+}
+
+// readLoop reads PTY output and sends it to the output channel.
+func (c *conmanConsoleIO) readLoop() {
+	buf := make([]byte, 4096)
+	for {
+		select {
+		case <-c.ctx.Done():
+			return
+		default:
+		}
+
+		c.mu.Lock()
+		ptmx := c.ptmx
+		c.mu.Unlock()
+
+		if ptmx == nil {
+			return
+		}
+
+		ready, err := waitForPTYReadable(int(ptmx.Fd()), 250*time.Millisecond)
+		if err != nil {
+			return
+		}
+		if !ready {
+			continue
+		}
+
+		n, err := ptmx.Read(buf)
+		if n > 0 {
+			data := make([]byte, n)
+			copy(data, buf[:n])
+			select {
+			case c.out <- data:
+			case <-c.ctx.Done():
+				return
+			}
+		}
+		if err != nil {
+			if err.Error() != "EOF" && !isEIO(err) {
+				slog.Error("PTY read error", "nodeID", c.nodeID, "error", err)
+			}
+			return
+		}
+	}
+}
+
+func (c *conmanConsoleIO) Output() <-chan []byte { return c.out }
+
+func (c *conmanConsoleIO) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	ptmx := c.ptmx
+	c.mu.Unlock()
+
+	if ptmx == nil {
+		return len(p), nil // silent drop during reconnect
+	}
+	return ptmx.Write(p)
+}
+
+func (c *conmanConsoleIO) Close() error {
+	c.closeOnce.Do(func() {
+		c.mu.Lock()
+		ptmx := c.ptmx
+		cmd := c.cmd
+		c.mu.Unlock()
+
+		if ptmx != nil {
+			// Send ConMan escape to gracefully disconnect.
+			_, _ = ptmx.Write([]byte("&."))
+			time.Sleep(100 * time.Millisecond)
+			_ = ptmx.Close()
+		}
+		if cmd != nil && cmd.Process != nil {
+			_ = cmd.Process.Signal(syscall.SIGTERM)
+		}
+
+		c.cancel()
+	})
+	return nil
+}
+
+// isEIO checks if an error is EIO (expected when a PTY process exits).
+func isEIO(err error) bool {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == syscall.EIO
+	}
+	return false
+}
+
+// waitForPTYReadable waits until the PTY fd is readable or the timeout elapses.
+func waitForPTYReadable(fd int, timeout time.Duration) (bool, error) {
+	var readSet unix.FdSet
+	readSet.Zero()
+	readSet.Set(fd)
+
+	tv := unix.NsecToTimeval(timeout.Nanoseconds())
+	n, err := unix.Select(fd+1, &readSet, nil, nil, &tv)
+	if err != nil {
+		if errors.Is(err, syscall.EINTR) {
+			return false, nil
+		}
+		return false, err
+	}
+	return n > 0, nil
+}

--- a/internal/console/consoleio.go
+++ b/internal/console/consoleio.go
@@ -1,0 +1,18 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package console
+
+// consoleIO abstracts the underlying console backend (PTY/conman or SSH).
+// Implementations handle reconnection internally; Output() is closed only on
+// permanent shutdown (context cancelled or node removed from inventory).
+type consoleIO interface {
+	// Output returns a channel of console output chunks. The channel is closed
+	// when the backend shuts down permanently.
+	Output() <-chan []byte
+	// Write sends data to the console (user input).
+	Write(p []byte) (n int, err error)
+	// Close shuts down the backend. Safe to call multiple times.
+	Close() error
+}

--- a/internal/console/interactive.go
+++ b/internal/console/interactive.go
@@ -6,21 +6,13 @@ package console
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
-	"os"
-	"os/exec"
 	"sync"
-	"syscall"
 	"time"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
-	"github.com/creack/pty"
 	"github.com/gorilla/websocket"
 	"github.com/nxadm/tail/ratelimiter"
 )
@@ -62,281 +54,80 @@ func (s *interactiveSessions) release(nodeID string) {
 	delete(s.active, nodeID)
 }
 
-// interactiveConsoleSession manages the lifecycle of an interactive console session
+// interactiveConsoleSession manages the lifecycle of an interactive console session.
 type interactiveConsoleSession struct {
-	cmd       *exec.Cmd
-	ptmx      *os.File
-	ptmxMutex sync.RWMutex // Protects ptmx during reconnection
-	nodeID    string
-
-	cancel context.CancelFunc
-
-	ws            *webSocketSession        // WebSocket session
-	rateLimiter   *ratelimiter.LeakyBucket // Rate limit console output
-	wg            sync.WaitGroup           // Tracks all goroutines
-	processExited chan struct{}            // Closed when current conman process exits
+	io          consoleIO
+	nodeID      string
+	cancel      context.CancelFunc
+	ws          *webSocketSession        // WebSocket session
+	rateLimiter *ratelimiter.LeakyBucket // Rate limit console output
+	wg          sync.WaitGroup           // Tracks all goroutines
 }
 
-// close performs graceful shutdown of the console session
-// This method is idempotent and safe to call multiple times
+// close shuts down the session. Safe to call multiple times.
 func (s *interactiveConsoleSession) close() {
 	s.closeWithReason(sessionCloseNormal, "")
 }
 
-// closeWithReason performs graceful shutdown of the console session with a specific reason
+// closeWithReason shuts down the session with a specific WebSocket close reason.
 func (s *interactiveConsoleSession) closeWithReason(reason sessionCloseReason, message string) {
-	slog.Info("Starting close for console session", "nodeID", s.nodeID)
+	slog.Info("Closing interactive console session", "nodeID", s.nodeID)
 
-	// Cancel context to signal all goroutines to stop
+	// 1. Shut down the backend (SSH detach or PTY SIGTERM). Idempotent.
+	if err := s.io.Close(); err != nil {
+		slog.Debug("Error closing console IO", "nodeID", s.nodeID, "error", err)
+	}
+
+	// 2. Cancel the session context to unblock both goroutines.
 	if s.cancel != nil {
 		s.cancel()
 	}
 
-	// Try graceful disconnect via ConMan escape sequence
-	s.ptmxMutex.RLock()
-	ptmx := s.ptmx
-	s.ptmxMutex.RUnlock()
-
-	if ptmx != nil {
-		slog.Info("Sending ConMan escape sequence (&.) to disconnect from console", "nodeID", s.nodeID)
-		// Ignore write errors - PTY might already be closed
-		if _, err := ptmx.Write([]byte("&.")); err != nil {
-			slog.Debug("Failed to write ConMan escape sequence", "nodeID", s.nodeID, "error", err)
-		}
-		time.Sleep(100 * time.Millisecond) // Brief pause to let it process
-	}
-
-	// Signal process termination (idempotent - safe to signal multiple times)
-	if s.cmd != nil && s.cmd.Process != nil {
-		slog.Info("Sending SIGTERM to conman process for console", "nodeID", s.nodeID)
-		// Ignore signal errors - process might already be dead
-		if err := s.cmd.Process.Signal(syscall.SIGTERM); err != nil {
-			slog.Debug("Failed to signal conman process", "nodeID", s.nodeID, "error", err)
-		}
-	}
-
-	// Close PTY - this will cause streamOutput to exit
-	s.ptmxMutex.Lock()
-	if s.ptmx != nil {
-		// Close returns error if already closed, but that's fine
-		if err := s.ptmx.Close(); err != nil {
-			slog.Debug("Failed to close PTY", "nodeID", s.nodeID, "error", err)
-		}
-		s.ptmx = nil
-	}
-	s.ptmxMutex.Unlock()
-
-	// Close WebSocket
+	// 3. Send a WebSocket close frame. This causes writePump to close the
+	//    underlying TCP connection, which unblocks streamInput's ReadMessage.
 	s.ws.close(reason, message)
-
-	slog.Info("Close completed for console session", "nodeID", s.nodeID)
 }
 
-// monitorProcess watches for process exit (conman) and attempts reconnection if node still exists
-// This runs in a loop, monitoring each new process after successful reconnection
-func (s *interactiveConsoleSession) monitorProcess(ctx context.Context) {
-	for {
-		select {
-		case <-s.processExited:
-		case <-ctx.Done():
-			slog.Info("Session closing, stopping monitor for console", "nodeID", s.nodeID)
-			return
-		}
-		slog.Info("Conman process exited for console", "nodeID", s.nodeID)
-
-		// Wait before reconnecting to prevent tight loop
-		select {
-		case <-time.After(time.Second):
-			// Continue to reconnection
-		case <-ctx.Done():
-			slog.Info("Session closing during reconnect delay, stopping monitor for console", "nodeID", s.nodeID)
-			return
-		}
-
-		// Check if the node still exists (might have been updated/changed)
-		if !nodes.IsCurrentNode(s.nodeID) {
-			slog.Info("Node no longer exists, closing session", "nodeID", s.nodeID)
-			s.closeWithReason(sessionCloseNormal, "node no longer exists")
-			return
-		}
-
-		slog.Info("Node still exists, attempting to reconnect", "nodeID", s.nodeID)
-		s.reconnect(ctx)
-
-	}
-}
-
-// startConmanProcess starts a new conman process with PTY
-func (s *interactiveConsoleSession) startConmanProcess(ctx context.Context) error {
-	// Check if session is closing
-	select {
-	case <-ctx.Done():
-		return fmt.Errorf("session closing, cannot start conman process: %w", ctx.Err())
-	default:
-	}
-
-	s.cmd = exec.Command("conman", s.nodeID)
-
-	ptmx, err := pty.Start(s.cmd)
-	if err != nil {
-		return fmt.Errorf("failed to start conman with PTY: %w", err)
-	}
-
-	s.ptmxMutex.Lock()
-	s.ptmx = ptmx
-	s.ptmxMutex.Unlock()
-
-	// Immediately start waiting on the process to avoid zombies
-	s.processExited = make(chan struct{})
-	go func() {
-		if err := s.cmd.Wait(); err != nil {
-			slog.Debug("Conman process wait ended with error", "nodeID", s.nodeID, "error", err)
-		}
-		// Notify monitorProcess of exit
-		close(s.processExited)
-	}()
-
-	return nil
-}
-
-// reconnect attempts to restart the conman process and reconnect streams
-// Logs errors but does not fail - monitorProcess will retry on next process exit
-func (s *interactiveConsoleSession) reconnect(ctx context.Context) {
-
-	// Notify user via WebSocket
-	reconnectMsg := fmt.Sprintf("\n[Reconnecting to %s...]\n", s.nodeID)
-	err := s.ws.Write(websocket.TextMessage, []byte(reconnectMsg))
-	if err != nil {
-		slog.Warn("WebSocket write failed, closing session", "nodeID", s.nodeID, "error", err)
-		s.closeWithReason(sessionCloseError, "websocket write failed")
-		return
-	}
-
-	// Close old PTY if it exists
-	s.ptmxMutex.Lock()
-	if s.ptmx != nil {
-		if err := s.ptmx.Close(); err != nil {
-			slog.Debug("Failed to close PTY during reconnect", "nodeID", s.nodeID, "error", err)
-		}
-	}
-	s.ptmxMutex.Unlock()
-
-	// Try to start conman again
-	slog.Info("Attempting to reconnect conman", "nodeID", s.nodeID)
-
-	if err := s.startConmanProcess(ctx); err != nil {
-		slog.Warn("Failed to start conman", "nodeID", s.nodeID, "error", err)
-		// Don't close - let monitorProcess retry
-		return
-	}
-
-	// Process started successfully
-	slog.Info("Successfully started conman for console", "nodeID", s.nodeID)
-
-	// Restart output streaming
-	// The console output itself will indicate when we're truly connected
-	// Track this new goroutine in the main WaitGroup
-	s.wg.Add(1)
-	go s.streamOutput(ctx)
-	// Note: streamInput is already running and will continue to work with the new PTY
-}
-
-// isEIO checks if an error is an I/O error (EIO)
-// This happens when reading from a PTY after the process has been killed
-func isEIO(err error) bool {
-	var errno syscall.Errno
-	if errors.As(err, &errno) {
-		return errno == syscall.EIO
-	}
-
-	return false
-}
-
-// waitForPTYReadable waits until the PTY file descriptor is readable or timeout occurs
-func waitForPTYReadable(fd int, timeout time.Duration) (bool, error) {
-	var readSet unix.FdSet
-	readSet.Zero()
-	readSet.Set(fd)
-
-	tv := unix.NsecToTimeval(timeout.Nanoseconds())
-	n, err := unix.Select(fd+1, &readSet, nil, nil, &tv)
-	if err != nil {
-		if errors.Is(err, syscall.EINTR) {
-			return false, nil
-		}
-		return false, err
-	}
-
-	return n > 0, nil
-}
-
-// streamOutput reads from PTY and writes to WebSocket
+// streamOutput reads console output from the backend and writes it to the WebSocket.
 func (s *interactiveConsoleSession) streamOutput(ctx context.Context) {
 	defer s.wg.Done()
 
-	buf := make([]byte, 4096)
 	for {
 		select {
 		case <-ctx.Done():
 			return
 		case <-s.ws.Done():
 			return
-		default:
-		}
-
-		s.ptmxMutex.RLock()
-		ptmx := s.ptmx
-		if ptmx == nil {
-			s.ptmxMutex.RUnlock()
-			slog.Debug("PTY is nil, exiting streamOutput for console", "nodeID", s.nodeID)
-			return
-		}
-		fd := int(ptmx.Fd())
-
-		// Wait for PTY to be readable with timeout, to allow checking for context cancellation, otherwise Read may block indefinitely
-		ready, err := waitForPTYReadable(fd, 250*time.Millisecond)
-		if err != nil {
-			s.ptmxMutex.RUnlock()
-			slog.Error("PTY read wait failed", "nodeID", s.nodeID, "error", err)
-			return
-		}
-		if !ready {
-			s.ptmxMutex.RUnlock()
-			continue
-		}
-
-		n, err := ptmx.Read(buf)
-		s.ptmxMutex.RUnlock()
-		if err != nil {
-			// Don't log I/O errors - they're expected when the process is killed
-			if err != io.EOF && !isEIO(err) {
-				slog.Error("Error reading from PTY", "nodeID", s.nodeID, "error", err)
+		case data, ok := <-s.io.Output():
+			if !ok {
+				// Backend shut down permanently.
+				s.close()
+				return
 			}
-			// PTY closed, exit gracefully without calling close() (close() already closed PTY)
-			return
-		}
 
-		if n > 0 {
-			slog.Debug("PTY read", "nodeID", s.nodeID, "bytes", n, "data", string(buf[:n]))
-
-			// Apply rate limiting (convert bytes to KB, rounded up)
-			kb := uint16((n + 1023) / 1024)
+			// Apply rate limiting.
+			kb := uint16((len(data) + 1023) / 1024)
 			for !s.rateLimiter.Pour(kb) {
-				slog.Debug("Rate limit reached, waiting for capacity", "nodeID", s.nodeID)
-				time.Sleep(100 * time.Millisecond) // Wait for bucket to drain
+				select {
+				case <-ctx.Done():
+					return
+				case <-s.ws.Done():
+					return
+				default:
+					time.Sleep(100 * time.Millisecond) // Wait for bucket to drain
+				}
 			}
 
-			err := s.ws.Write(websocket.BinaryMessage, buf[:n])
-			if err != nil {
+			if err := s.ws.Write(websocket.BinaryMessage, data); err != nil {
 				// WebSocket closed/cancelled, exit gracefully
-				slog.Info("WebSocket write failed", "nodeID", s.nodeID, "error", err)
+				slog.Info("WebSocket write failed, closing session", "nodeID", s.nodeID, "error", err)
 				return
 			}
 		}
 	}
 }
 
-// streamInput reads from WebSocket and writes to PTY
+// streamInput reads from the WebSocket and writes user input to the console backend.
 func (s *interactiveConsoleSession) streamInput(ctx context.Context) {
 	defer s.wg.Done()
 
@@ -354,31 +145,25 @@ func (s *interactiveConsoleSession) streamInput(ctx context.Context) {
 		messageType, message, err := s.ws.Read()
 		if err != nil {
 			// Check if it's an unexpected close (not normal, going away, or abnormal)
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseNormalClosure, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
-				slog.Warn("WebSocket unexpected close error", "nodeID", s.nodeID, "error", err)
+			if websocket.IsUnexpectedCloseError(err,
+				websocket.CloseNormalClosure,
+				websocket.CloseGoingAway,
+				websocket.CloseAbnormalClosure,
+			) {
+				slog.Warn("WebSocket unexpected close", "nodeID", s.nodeID, "error", err)
 				s.closeWithReason(sessionCloseError, "websocket read failed")
 			} else {
-				slog.Info("WebSocket closed normally for console", "nodeID", s.nodeID)
+				slog.Info("WebSocket closed normally", "nodeID", s.nodeID)
 				s.close()
 			}
 			return
 		}
 
 		if messageType == websocket.TextMessage || messageType == websocket.BinaryMessage {
-			// Write user input to PTY
-			// Hold RLock during the entire write to prevent reconnect() from swapping PTY
-			s.ptmxMutex.RLock()
-			if s.ptmx == nil {
-				s.ptmxMutex.RUnlock()
-				slog.Debug("PTY is nil, skipping input for console", "nodeID", s.nodeID)
-				continue
-			}
-
-			_, err := s.ptmx.Write(message)
-			s.ptmxMutex.RUnlock()
-
-			if err != nil {
-				slog.Error("Failed to write to PTY", "nodeID", s.nodeID, "error", err)
+			// Both backends return len(p), nil when disconnected (silent drop),
+			// so write errors here indicate a genuine problem worth logging.
+			if _, err := s.io.Write(message); err != nil {
+				slog.Error("Failed to write to console backend", "nodeID", s.nodeID, "error", err)
 				s.closeWithReason(sessionCloseError, "failed to write to console")
 				return
 			}
@@ -386,31 +171,13 @@ func (s *interactiveConsoleSession) streamInput(ctx context.Context) {
 	}
 }
 
-// Start begins the console session by launching all goroutines and waiting for completion
-func (s *interactiveConsoleSession) Start(ctx context.Context) {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
-	sessionCtx, cancel := context.WithCancel(ctx)
+// Start launches the session goroutines and blocks until both exit.
+func (s *interactiveConsoleSession) Start() {
+	sessionCtx, cancel := context.WithCancel(context.Background())
 	s.cancel = cancel
 
 	// Start WebSocket session
 	s.ws.Start()
-
-	// Start initial conman process with PTY
-	if err := s.startConmanProcess(sessionCtx); err != nil {
-		slog.Error("Failed to start conman with PTY", "nodeID", s.nodeID, "error", err)
-		err = s.ws.Write(websocket.TextMessage, []byte("Error: Failed to start conman with PTY"))
-		if err != nil {
-			slog.Warn("Failed to send error message via WebSocket", "nodeID", s.nodeID, "error", err)
-		}
-		s.closeWithReason(sessionCloseError, "failed to connect to console")
-		return
-	}
-
-	// Monitor process exit for reconnection attempts
-	go s.monitorProcess(sessionCtx)
 
 	// Start I/O goroutines
 	s.wg.Add(2)
@@ -421,8 +188,9 @@ func (s *interactiveConsoleSession) Start(ctx context.Context) {
 	s.wg.Wait()
 }
 
-func newInteractiveConsoleSession(nodeID string, conn *websocket.Conn) *interactiveConsoleSession {
+func newInteractiveConsoleSession(nodeID string, conn *websocket.Conn, cio consoleIO) *interactiveConsoleSession {
 	session := &interactiveConsoleSession{
+		io:          cio,
 		nodeID:      nodeID,
 		rateLimiter: ratelimiter.NewLeakyBucket(rateLimitBurstKB, rateLimitInterval),
 	}
@@ -443,18 +211,18 @@ func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, 
 	}
 
 	// Make sure we are monitoring a valid node
-	if exists := nodes.IsCurrentNode(nodeID); !exists {
-		http.Error(w, "Node doesn't exists", http.StatusNotFound)
+	node := nodes.CurrentNodes()[nodeID]
+	if node == nil {
+		http.Error(w, "Node doesn't exist", http.StatusNotFound)
 		return
 	}
-
 	if ok := sessions.reserve(nodeID); !ok {
 		http.Error(w, fmt.Sprintf("Console %s is already in use", nodeID), http.StatusConflict)
 		return
 	}
 	defer sessions.release(nodeID)
 
-	slog.Info("Starting interactive console session", "nodeID", nodeID)
+	slog.Info("Starting interactive console session", "nodeID", nodeID, "backend", "conman")
 
 	// Upgrade HTTP connection to WebSocket
 	conn, err := upgrader.Upgrade(w, r, nil)
@@ -465,11 +233,20 @@ func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, 
 	}
 
 	// From here on, errors must be sent via WebSocket close frames
-	session := newInteractiveConsoleSession(nodeID, conn)
+	cio, err := newConmanConsoleIO(nodeID)
+	if err != nil {
+		slog.Error("Failed to create console IO backend", "nodeID", nodeID, "error", err)
+		_ = conn.WriteMessage(websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseInternalServerErr, "failed to connect to console"))
+		_ = conn.Close()
+		return
+	}
+
+	session := newInteractiveConsoleSession(nodeID, conn, cio)
 	defer session.close() // Ensure cleanup always happens
 
 	// Start session (blocks until all goroutines complete)
-	session.Start(r.Context())
+	session.Start()
 
 	slog.Info("Interactive console session ended", "nodeID", nodeID)
 }


### PR DESCRIPTION
Move interactive ConMan sessions behind a shared console I/O interface and a reconnecting ConMan backend. This preserves existing routing behavior while establishing the abstraction used by the next PR.