### PR TITLE
feat(console): route consoles through in-process backends

### DIFF
--- a/cmd/remote-console/service.go
+++ b/cmd/remote-console/service.go
@@ -22,6 +22,7 @@ import (
 	"github.com/OpenCHAMI/remote-console/internal/creds"
 	"github.com/OpenCHAMI/remote-console/internal/logs"
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
+	"github.com/OpenCHAMI/remote-console/internal/ssh"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/clientcredentials"
 )
@@ -50,10 +51,53 @@ type LogsService interface {
 	AggregateFiles(consoleLogsPath string, nodes map[string]*nodes.NodeConsoleInfo)
 }
 
+// SSHConsoleService defines the management interface for the SSH console manager.
+// Interactive access (Attach/Detach/Write) flows through the console.SSHManager
+// interface, which is passed directly to console.SetupRoutes.
+type SSHConsoleService interface {
+	UpdateNodes(ctx context.Context, sshNodes map[string]*nodes.NodeConsoleInfo,
+		passwords map[string]compcreds.CompCredentials) error
+	UpdateCredentials(passwords map[string]compcreds.CompCredentials)
+	ReopenLogs()
+}
+
+// filterSSHNodes returns the subset of nodes with SSH connection type.
+func filterSSHNodes(allNodes map[string]*nodes.NodeConsoleInfo) map[string]*nodes.NodeConsoleInfo {
+	result := make(map[string]*nodes.NodeConsoleInfo)
+	for id, n := range allNodes {
+		if n.IsSSH() {
+			result[id] = n
+		}
+	}
+	return result
+}
+
+// filterIPMINodes returns the subset of nodes with IPMI connection type.
+func filterIPMINodes(allNodes map[string]*nodes.NodeConsoleInfo) map[string]*nodes.NodeConsoleInfo {
+	result := make(map[string]*nodes.NodeConsoleInfo)
+	for id, n := range allNodes {
+		if n.ConnectionType == nodes.IPMI {
+			result[id] = n
+		}
+	}
+	return result
+}
+
+// filterXNames returns the xnames from a node map.
+func filterXNames(sshNodes map[string]*nodes.NodeConsoleInfo) []string {
+	xnames := make([]string, 0, len(sshNodes))
+	for id := range sshNodes {
+		xnames = append(xnames, id)
+	}
+	return xnames
+}
+
 // Watch for node updates and signal conman and log rotation as needed
-func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpClient *http.Client, conmanService ConmanService, logsService LogsService) {
-	// conman will add the conman directory, so we point the logs service their
-	conmanLogsPath := filepath.Join(config.Conman.LogsPath, "conman")
+func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpClient *http.Client,
+	conmanService ConmanService, logsService LogsService,
+	credsService CredsService, sshService SSHConsoleService) {
+	// ConMan writes console files in a conman subdirectory.
+	consoleLogsPath := filepath.Join(config.Log.ConsoleLogsBasePath, "conman")
 
 	ticker := time.NewTicker(time.Duration(config.NewNodeLookup) * time.Second)
 	defer ticker.Stop()
@@ -67,29 +111,45 @@ func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpC
 			changed := nodes.CheckForUpdates(ctx, httpClient, config.SmdURL)
 
 			if changed {
-				slog.Info("Node changes detected, signaling conman to restart")
+				slog.Info("Node changes detected, reconfiguring services")
+
+				currentNodes := nodes.CurrentNodes()
+				passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(currentNodes), 15, 10)
+				if err != nil {
+					slog.Error("Failed to fetch credentials for updated nodes", "error", err)
+				} else {
+					// Regenerate conman config with the new node list and credentials.
+					if _, err := conmanService.ConfigureConman(filterIPMINodes(currentNodes), passwords, config.Creds.SshConsoleKeyPath); err != nil {
+						slog.Error("Failed to reconfigure conman", "error", err)
+					}
+					// Update SSH nodes with current topology and credentials.
+					if err := sshService.UpdateNodes(ctx, filterSSHNodes(currentNodes), passwords); err != nil {
+						slog.Error("Failed to update SSH console manager", "error", err)
+					}
+				}
+
+				// Restart conman to pick up the new config.
 				if err := conmanService.SignalConmanTERM(); err != nil {
 					slog.Error("Failed to signal conman with SIGTERM", "error", err)
 				}
 
-				nodes := nodes.CurrentNodes()
-
 				// also update log rotation configuration
 				slog.Info("Updating log rotation configuration for node changes")
-				if err := logsService.UpdateLogRotateConf(conmanLogsPath, nodes); err != nil {
+				if err := logsService.UpdateLogRotateConf(consoleLogsPath, currentNodes); err != nil {
 					slog.Error("Failed to update log rotation configuration for node changes", "error", err)
 				}
 
 				// make sure we are aggregating any new console log files
 				slog.Info("Updating log aggregation configuration for node changes")
-				logsService.AggregateFiles(conmanLogsPath, nodes)
+				logsService.AggregateFiles(consoleLogsPath, currentNodes)
 			}
 		}
 	}
 }
 
-// Watch for credential updates and signal conman as needed
-func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig, credsService CredsService, conmanService ConmanService) {
+// Watch for credential updates and signal conman and SSH manager as needed
+func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig,
+	credsService CredsService, conmanService ConmanService, sshService SSHConsoleService) {
 	ticker := time.NewTicker(time.Duration(config.CredsMonitorInterval) * time.Second)
 	defer ticker.Stop()
 
@@ -105,7 +165,22 @@ func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig, credsS
 			}
 
 			if changed {
-				slog.Info("Credential changes detected, signaling conman to restart")
+				slog.Info("Credential changes detected, reconfiguring services")
+
+				currentNodes := nodes.CurrentNodes()
+				passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(currentNodes), 3, 5)
+				if err != nil {
+					slog.Error("Failed to fetch updated credentials", "error", err)
+				} else {
+					// Regenerate conman config so IPMI nodes pick up the new credentials.
+					if _, err := conmanService.ConfigureConman(filterIPMINodes(currentNodes), passwords, config.Creds.SshConsoleKeyPath); err != nil {
+						slog.Error("Failed to reconfigure conman with updated credentials", "error", err)
+					}
+					// Push updated credentials to SSH nodes.
+					sshService.UpdateCredentials(passwords)
+				}
+
+				// Always restart conman regardless of config update outcome.
 				if err := conmanService.SignalConmanTERM(); err != nil {
 					slog.Error("Failed to signal conman with SIGTERM", "error", err)
 				}
@@ -115,7 +190,7 @@ func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig, credsS
 }
 
 // Log rotation setup and loop
-func logRotate(ctx context.Context, config remoteConsoleConfig, conmanService ConmanService, logsService LogsService) {
+func logRotate(ctx context.Context, config remoteConsoleConfig, conmanService ConmanService, logsService LogsService, sshService SSHConsoleService) {
 	logConfig := config.Log
 	// log the log rotation parameters
 	slog.Info("Log rotation configuration",
@@ -126,11 +201,11 @@ func logRotate(ctx context.Context, config remoteConsoleConfig, conmanService Co
 		"aggFileSize", logConfig.AggLogsFileSize,
 		"aggNumRotate", logConfig.AggLogsNumRotate)
 
-	// conman will add the conman directory, so we point the logs service their
-	conmanLogsPath := filepath.Join(config.Conman.LogsPath, "conman")
+	// ConMan writes console files in a conman subdirectory.
+	consoleLogsPath := filepath.Join(config.Log.ConsoleLogsBasePath, "conman")
 
 	// Create the log rotation configuration file
-	if err := logsService.UpdateLogRotateConf(conmanLogsPath, nodes.CurrentNodes()); err != nil {
+	if err := logsService.UpdateLogRotateConf(consoleLogsPath, nodes.CurrentNodes()); err != nil {
 		slog.Error("Failed to update log rotation configuration", "error", err)
 	}
 
@@ -151,12 +226,13 @@ func logRotate(ctx context.Context, config remoteConsoleConfig, conmanService Co
 			slog.Info("Exiting log rotation loop due to shutdown")
 			return
 		case <-ticker.C:
-			restartConman := logsService.LogRotate(conmanLogsPath)
-			if restartConman {
-				slog.Info("Log files rotated, signaling conmand")
+			consoleLogsRotated := logsService.LogRotate(consoleLogsPath)
+			if consoleLogsRotated {
+				slog.Info("Log files rotated, signalling conmand and SSH manager")
 				if err := conmanService.SignalConmanHUP(); err != nil {
 					slog.Error("Failed to signal conman with SIGHUP", "error", err)
 				}
+				sshService.ReopenLogs()
 			}
 		}
 	}
@@ -183,21 +259,21 @@ func runConman(ctx context.Context, config remoteConsoleConfig, conmanService Co
 		}
 
 		currentNodes := nodes.CurrentNodes()
+		ipmiNodes := filterIPMINodes(currentNodes)
 
-		var requireCredentials []string
-		for _, nci := range currentNodes {
-			requireCredentials = append(requireCredentials, nci.ID)
-		}
-
-		passwords, err := credService.GetPasswordsWithRetries(ctx, requireCredentials, 15, 10)
-		if err != nil {
-			slog.Warn("Credential retrieval ended early", "error", err)
-			if errors.Is(err, context.Canceled) {
-				return
+		var passwords map[string]compcreds.CompCredentials
+		var err error
+		if len(ipmiNodes) > 0 {
+			passwords, err = credService.GetPasswordsWithRetries(ctx, filterXNames(ipmiNodes), 15, 10)
+			if err != nil {
+				slog.Warn("Credential retrieval ended early", "error", err)
+				if errors.Is(err, context.Canceled) {
+					return
+				}
 			}
 		}
 
-		hasNodes, err := conmanService.ConfigureConman(currentNodes, passwords, config.Creds.SshConsoleKeyPath)
+		hasNodes, err := conmanService.ConfigureConman(ipmiNodes, passwords, config.Creds.SshConsoleKeyPath)
 		if err != nil {
 			slog.Error("Failed to configure conman", "error", err)
 			if waitWithContext(5 * time.Second) {
@@ -232,11 +308,10 @@ func runService(config remoteConsoleConfig) error {
 
 	conmanService := conman.NewConmanService(config.Conman)
 
-	// Conman will append "conman" to this path for its logs, so we
-	// need to pass that full path to service monitoring the logs
-	conmanLogsPath := filepath.Join(config.Conman.LogsPath, "conman")
-	if err := os.MkdirAll(conmanLogsPath, 0755); err != nil {
-		slog.Error("Failed to create console logs directory", "path", conmanLogsPath, "error", err)
+	// ConMan writes console files in a conman subdirectory.
+	consoleLogsPath := filepath.Join(config.Log.ConsoleLogsBasePath, "conman")
+	if err := os.MkdirAll(consoleLogsPath, 0755); err != nil {
+		slog.Error("Failed to create console logs directory", "path", consoleLogsPath, "error", err)
 		return err
 	}
 
@@ -288,17 +363,31 @@ func runService(config remoteConsoleConfig) error {
 		}
 	}
 
+	// Create the SSH console manager.
+	sshManager := ssh.NewSSHConsoleManager(config.SSH, config.Creds.SshConsoleKeyPath, consoleLogsPath)
+
+	// Seed SSH nodes immediately — watchForNodesUpdates only fires after the first tick.
+	initialSSHNodes := filterSSHNodes(nodes.CurrentNodes())
+	if len(initialSSHNodes) > 0 {
+		initialXNames := filterXNames(initialSSHNodes)
+		if passwords, err := credsService.GetPasswordsWithRetries(serviceCtx, initialXNames, 15, 10); err != nil {
+			slog.Warn("Failed to fetch initial SSH credentials", "error", err)
+		} else if err := sshManager.UpdateNodes(serviceCtx, initialSSHNodes, passwords); err != nil {
+			slog.Error("Failed initial SSH manager node update", "error", err)
+		}
+	}
+
 	// goroutine for log rotation
-	go logRotate(serviceCtx, config, conmanService, logsService)
+	go logRotate(serviceCtx, config, conmanService, logsService, sshManager)
 
 	// goroutine to watches for changes in console configuration
-	go watchForNodesUpdates(serviceCtx, config, smdHTTPClient, conmanService, logsService)
+	go watchForNodesUpdates(serviceCtx, config, smdHTTPClient, conmanService, logsService, credsService, sshManager)
 
 	// goroutine to run conman
 	go runConman(serviceCtx, config, conmanService, credsService)
 
 	// goroutine watch for credential updates
-	go watchForCredUpdates(serviceCtx, config, credsService, conmanService)
+	go watchForCredUpdates(serviceCtx, config, credsService, conmanService, sshManager)
 
 	// Initialize JWT token authorization if JWKS URL is provided
 	if config.JwksURL != "" {
@@ -342,7 +431,7 @@ func runService(config remoteConsoleConfig) error {
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
 
-	router := console.SetupRoutes(conmanLogsPath)
+	router := console.SetupRoutes(consoleLogsPath, sshManager)
 
 	slog.Info("Starting HTTP server", "address", config.HttpListen)
 	server := &http.Server{Addr: config.HttpListen, Handler: router}

--- a/internal/conman/config.go
+++ b/internal/conman/config.go
@@ -7,7 +7,7 @@ package conman
 type ConmanConfig struct {
 	BaseConfFilePath   string `desc:"Path to the base conman configuration template file."`
 	ConfFilePath       string `desc:"Path to the generated conman configuration file."`
-	LogsPath           string `desc:"Path to conman log files."`
+	LogsPath           string `desc:"Deprecated alias for console-logs-base-path."`
 	PidFilePath        string `desc:"Path to the conman PID file."`
 	ConsoleScriptsPath string `desc:"Path to console helper scripts."`
 }

--- a/internal/conman/conman.go
+++ b/internal/conman/conman.go
@@ -10,7 +10,6 @@ package conman
 import (
 	"bufio"
 	"bytes"
-	"encoding/base64"
 	"fmt"
 	"io"
 	"log/slog"
@@ -101,27 +100,6 @@ func generateIPMIConsoleConfig(nci *nodes.NodeConsoleInfo, creds compcredentials
 		nci.ID, nci.ConnectionHost, creds.Username, creds.Password)
 }
 
-func (cs *ConmanService) generateSSHConsoleConfig(nci *nodes.NodeConsoleInfo, creds compcredentials.CompCredentials, sshConsoleKeyPath string) string {
-	var devArgs string
-
-	// If we have password creds, use those, otherwise use key-based.
-	if creds.Password != "" {
-		slog.Debug("Configuring SSH console with password", "nodeID", nci.ID, "host", nci.ConnectionHost, "port", nci.ConnectionPort, "username", creds.Username, "entryCmd", nci.ConsoleEntryCommand)
-		devArgs = fmt.Sprintf("%s/ssh-pwd-console %s %d %s %s", cs.config.ConsoleScriptsPath, nci.ConnectionHost, nci.ConnectionPort, creds.Username, creds.Password)
-	} else {
-		// Key based auth, note that we still use the username from the secure store.
-		slog.Debug("Configuring SSH console with key", "nodeID", nci.ID, "host", nci.ConnectionHost, "port", nci.ConnectionPort, "username", creds.Username, "keyPath", sshConsoleKeyPath, "entryCmd", nci.ConsoleEntryCommand)
-		devArgs = fmt.Sprintf("%s/ssh-key-console %s %d %s %s", cs.config.ConsoleScriptsPath, nci.ConnectionHost, nci.ConnectionPort, creds.Username, sshConsoleKeyPath)
-	}
-
-	if nci.ConsoleEntryCommand != "" {
-		// Encode the entry command in base64 to avoid issues with special characters, conman can't handle escaping quotes.
-		base64EncodedCmd := base64.StdEncoding.EncodeToString([]byte(nci.ConsoleEntryCommand))
-		devArgs = fmt.Sprintf("%s %s", devArgs, base64EncodedCmd)
-	}
-
-	return fmt.Sprintf("console name=\"%s\" dev=\"%s\"\n", nci.ID, devArgs)
-}
 
 func (cs *ConmanService) updateConfigFile(nodeMap map[string]*nodes.NodeConsoleInfo, passwords map[string]compcredentials.CompCredentials, sshConsoleKeyPath string, forceUpdate bool) (bool, error) {
 	slog.Info("Updating conman configuration file")
@@ -155,23 +133,24 @@ func (cs *ConmanService) updateConfigFile(nodeMap map[string]*nodes.NodeConsoleI
 	slog.Info("Populating conman configuration with nodes", "nodeCount", len(nodeMap))
 
 	consoles := make([]string, 0, len(nodeMap))
+	ipmiCount := 0
 
 	for _, nci := range nodeMap {
-		creds, ok := passwords[nci.ID]
-		if !ok {
-			slog.Warn("No credentials found for node", "nodeID", nci.ID)
-		}
-
 		switch nci.ConnectionType {
-		// IPMI connection
 		case nodes.IPMI:
-			output := generateIPMIConsoleConfig(nci, creds)
-			consoles = append(consoles, output)
+			creds, ok := passwords[nci.ID]
+			if !ok {
+				slog.Warn("No credentials found for node", "nodeID", nci.ID)
+			}
+			consoles = append(consoles, generateIPMIConsoleConfig(nci, creds))
+			ipmiCount++
 
-		// SSH connection
 		case nodes.SSH:
-			output := cs.generateSSHConsoleConfig(nci, creds, sshConsoleKeyPath)
-			consoles = append(consoles, output)
+			// Callers filter to IPMI nodes before calling, so reaching this is a
+			// caller bug rather than routine. Skipping is still the right
+			// response: writing a conman console for an SSH node would put a
+			// second process on a console SSHConsoleManager is already driving.
+			slog.Error("SSH node passed to conman config; skipping", "nodeID", nci.ID)
 		}
 	}
 
@@ -183,7 +162,8 @@ func (cs *ConmanService) updateConfigFile(nodeMap map[string]*nodes.NodeConsoleI
 		}
 	}
 
-	return len(nodeMap) > 0, nil
+	// Only report hasNodes=true for IPMI nodes; SSH nodes don't need conman.
+	return ipmiCount > 0, nil
 }
 
 // SignalConmanTERM sends SIGTERM to running conmand process

--- a/internal/conman/conman_test.go
+++ b/internal/conman/conman_test.go
@@ -99,6 +99,8 @@ func TestConfigureConman(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, generatedConfig)
 
+	// SSH nodes (x0c0s2b0, x0c0s3b0) are managed by SSHConsoleManager and must
+	// not appear in the conman config.
 	expected := `# UPDATE_CONFIG=TRUE
 SERVER keepalive=ON
 SERVER logdir="/logs"
@@ -111,8 +113,6 @@ GLOBAL seropts="115200,8n1"
 GLOBAL log="conman/console.%N"
 GLOBAL logopts="sanitize,timestamp"
 console name="x0c0s1b0" dev="ipmi:x0c0s1b0" ipmiopts="U:admin,P:password1,W:solpayloadsize"
-console name="x0c0s2b0" dev="/usr/bin/ssh-key-console x0c0s2b0 2222 admin /tmp/ssh_console_key"
-console name="x0c0s3b0" dev="/usr/bin/ssh-pwd-console x0c0s3b0 0 admin password3"
 `
 	// Remove temporary directory path from generated config for comparison
 	generatedConfigStr := string(generatedConfig)

--- a/internal/console/interactive.go
+++ b/internal/console/interactive.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
+	"github.com/OpenCHAMI/remote-console/internal/ssh"
 	"github.com/gorilla/websocket"
 	"github.com/nxadm/tail/ratelimiter"
 )
@@ -200,7 +201,7 @@ func newInteractiveConsoleSession(nodeID string, conn *websocket.Conn, cio conso
 	return session
 }
 
-func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, r *http.Request) {
+func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, r *http.Request, sshMgr *ssh.SSHConsoleManager) {
 	// Make sure the request is cleaned up
 	defer drainAndCloseRequestBody(r)
 
@@ -216,13 +217,15 @@ func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, 
 		http.Error(w, "Node doesn't exist", http.StatusNotFound)
 		return
 	}
+	useSSH := node.IsSSH()
+
 	if ok := sessions.reserve(nodeID); !ok {
 		http.Error(w, fmt.Sprintf("Console %s is already in use", nodeID), http.StatusConflict)
 		return
 	}
 	defer sessions.release(nodeID)
 
-	slog.Info("Starting interactive console session", "nodeID", nodeID, "backend", "conman")
+	slog.Info("Starting interactive console session", "nodeID", nodeID, "backend", map[bool]string{true: "ssh", false: "conman"}[useSSH])
 
 	// Upgrade HTTP connection to WebSocket
 	conn, err := upgrader.Upgrade(w, r, nil)
@@ -233,7 +236,12 @@ func doInteractiveConsole(sessions *interactiveSessions, w http.ResponseWriter, 
 	}
 
 	// From here on, errors must be sent via WebSocket close frames
-	cio, err := newConmanConsoleIO(nodeID)
+	var cio consoleIO
+	if useSSH {
+		cio, err = newSSHConsoleIO(nodeID, sshMgr)
+	} else {
+		cio, err = newConmanConsoleIO(nodeID)
+	}
 	if err != nil {
 		slog.Error("Failed to create console IO backend", "nodeID", nodeID, "error", err)
 		_ = conn.WriteMessage(websocket.CloseMessage,

--- a/internal/console/router.go
+++ b/internal/console/router.go
@@ -15,6 +15,8 @@ import (
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/gorilla/websocket"
 	openchami_authenticator "github.com/openchami/chi-middleware/auth"
+
+	"github.com/OpenCHAMI/remote-console/internal/ssh"
 )
 
 const routePrefix = "/remote-console"
@@ -29,7 +31,7 @@ var upgrader = websocket.Upgrader{
 }
 
 // doConsole dispatches to either interactive or tail mode based on the mode query parameter
-func doConsole(consoleLogsPath string, sessions *interactiveSessions, w http.ResponseWriter, r *http.Request) {
+func doConsole(consoleLogsPath string, sessions *interactiveSessions, sshMgr *ssh.SSHConsoleManager, w http.ResponseWriter, r *http.Request) {
 	// Parse mode parameter (defaults to "interactive")
 	params := r.URL.Query()
 	mode := params.Get("mode")
@@ -41,13 +43,13 @@ func doConsole(consoleLogsPath string, sessions *interactiveSessions, w http.Res
 	case "tail":
 		doTailConsole(consoleLogsPath, w, r)
 	case "interactive":
-		doInteractiveConsole(sessions, w, r)
+		doInteractiveConsole(sessions, w, r, sshMgr)
 	default:
 		http.Error(w, fmt.Sprintf("Invalid mode parameter: %s (must be 'interactive' or 'tail')", mode), http.StatusBadRequest)
 	}
 }
 
-func SetupRoutes(consoleLogsPath string) *chi.Mux {
+func SetupRoutes(consoleLogsPath string, sshMgr *ssh.SSHConsoleManager) *chi.Mux {
 	router := chi.NewRouter()
 	interactiveSessions := newInteractiveSessions()
 
@@ -74,7 +76,7 @@ func SetupRoutes(consoleLogsPath string) *chi.Mux {
 
 			r.Get("/consoles", doConsoles)
 			r.Get("/consoles/{nodeID}", func(w http.ResponseWriter, r *http.Request) {
-				doConsole(consoleLogsPath, interactiveSessions, w, r)
+				doConsole(consoleLogsPath, interactiveSessions, sshMgr, w, r)
 			})
 		})
 	})

--- a/internal/console/ssh_backend.go
+++ b/internal/console/ssh_backend.go
@@ -1,0 +1,57 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package console
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	"github.com/OpenCHAMI/remote-console/internal/ssh"
+)
+
+// clientIDCounter generates unique client IDs within a process.
+var clientIDCounter atomic.Uint64
+
+func generateClientID() string {
+	return strconv.FormatUint(clientIDCounter.Add(1), 10)
+}
+
+// sshConsoleIO implements consoleIO backed by an SSHConsoleNode attachment.
+type sshConsoleIO struct {
+	nodeID    string
+	clientID  string
+	out       chan []byte
+	manager   *ssh.SSHConsoleManager
+	closeOnce sync.Once
+}
+
+func newSSHConsoleIO(nodeID string, manager *ssh.SSHConsoleManager) (*sshConsoleIO, error) {
+	clientID := generateClientID()
+	ch, err := manager.Attach(nodeID, clientID)
+	if err != nil {
+		return nil, fmt.Errorf("attach SSH console %s: %w", nodeID, err)
+	}
+	return &sshConsoleIO{
+		nodeID:   nodeID,
+		clientID: clientID,
+		out:      ch,
+		manager:  manager,
+	}, nil
+}
+
+func (s *sshConsoleIO) Output() <-chan []byte { return s.out }
+
+func (s *sshConsoleIO) Write(p []byte) (int, error) {
+	return s.manager.Write(s.nodeID, p)
+}
+
+func (s *sshConsoleIO) Close() error {
+	s.closeOnce.Do(func() {
+		s.manager.Detach(s.nodeID, s.clientID)
+	})
+	return nil
+}

--- a/internal/creds/creds.go
+++ b/internal/creds/creds.go
@@ -141,8 +141,6 @@ func (cs *CredsService) GetPasswordsWithRetries(ctx context.Context, bmcXNames [
 	}
 	slog.Warn("Maximum password attempts reached, configuring conman with what we have")
 
-	cs.previousPasswords = passwords
-
 	return passwords, err
 }
 

--- a/internal/creds/monitor.go
+++ b/internal/creds/monitor.go
@@ -42,15 +42,19 @@ func (cs *CredsService) CheckForUpdates() (bool, error) {
 }
 
 func (cs *CredsService) checkIfPasswordsChanged(xnames []string) (bool, error) {
-	if cs.previousPasswords == nil {
-		return false, nil
-	}
 	currentPasswords, err := getPasswords(cs.config, xnames)
 
 	if err != nil {
 		slog.Error("Error retrieving passwords while checking for credential changes", "error", err)
 		return false, err
 	}
+
+	if cs.previousPasswords == nil {
+		cs.previousPasswords = currentPasswords
+		return false, nil
+	}
+
+	changed := false
 	for _, xname := range xnames {
 		currentCreds, ok := currentPasswords[xname]
 		if !ok {
@@ -61,11 +65,16 @@ func (cs *CredsService) checkIfPasswordsChanged(xnames []string) (bool, error) {
 
 		if (currentCreds.Username != previousCreds.Username) || (currentCreds.Password != previousCreds.Password) {
 			slog.Info("Change detected in the passwords. Conman will be reconfigured.")
-			return true, nil
+			changed = true
+			break
 		}
 	}
 
-	return false, nil
+	// Only the full inventory refresh owns this snapshot. Credential reads for
+	// a subset of nodes must not make every omitted node appear changed later.
+	cs.previousPasswords = currentPasswords
+
+	return changed, nil
 }
 
 func (cs *CredsService) checkIfKeysChanged() (bool, error) {

--- a/internal/creds/monitor_test.go
+++ b/internal/creds/monitor_test.go
@@ -56,10 +56,6 @@ func TestCheckIfPasswordsChanged(t *testing.T) {
 
 	require.False(t, changed, "Passwords should not have changed")
 
-	// Call GetPasswordsWithRetry to set previousPasswords
-	_, err = service.GetPasswordsWithRetries(context.Background(), nodes, 3, 1)
-	require.NoError(t, err)
-
 	// Now change a password
 	value := map[string]string{
 		"Username": "admin",
@@ -76,6 +72,15 @@ func TestCheckIfPasswordsChanged(t *testing.T) {
 	}
 
 	require.True(t, changed, "Passwords should have changed")
+
+	// Reading a subset for conman must not replace the complete comparison
+	// snapshot and make the omitted node look changed on every refresh.
+	_, err = service.GetPasswordsWithRetries(context.Background(), nodes[:1], 1, 0)
+	require.NoError(t, err)
+
+	changed, err = service.checkIfPasswordsChanged(nodes)
+	require.NoError(t, err)
+	require.False(t, changed, "A subset read should not poison the credential snapshot")
 }
 
 func TestCheckIfKeysChanged(t *testing.T) {

--- a/test/containers.go
+++ b/test/containers.go
@@ -508,7 +508,7 @@ func startRemoteConsoleWithEnv(ctx context.Context, envOverrides map[string]stri
 			"RCS_CREDS_MONITOR_INTERVAL":             "10",
 			"RCS_CREDS_SECURE_STORAGE_SSH_KEYS_PATH": "hms-creds/bmc-console-keys",
 			"RCS_CONMAN_PID_FILE_PATH":               "/app/remote-console.pid",
-			"RCS_CONMAN_LOGS_PATH":                   "/tmp",
+			"RCS_CONSOLE_LOGS_BASE_PATH":             "/tmp",
 			// Log rotation settings for testing
 			"RCS_LOG_ROTATE_CHECK_FREQUENCY": "5",  // Check every 5 seconds
 			"RCS_CONSOLE_LOGS_FILE_SIZE":     "5M", // Small size to trigger rotation easily

--- a/test/credentials_test.go
+++ b/test/credentials_test.go
@@ -54,8 +54,8 @@ func (s *IntegrationTestSuite) TestConsoleCredentialRefresh() {
 	s.T().Log("Waiting for credential monitor to detect change...")
 	time.Sleep(15 * time.Second)
 
-	// SSH returns "Permission denied, please try again." when password auth fails.
-	authOutput, err := s.readWebSocketUntil(wsConn, "Permission denied", 2*time.Minute)
+	// The Go SSH backend broadcasts a connect-failed marker when authentication fails.
+	authOutput, err := s.readWebSocketUntil(wsConn, fmt.Sprintf("[Console %s connect failed:", nodeID), 2*time.Minute)
 	s.Require().NoError(err, "expected authentication error after credentials were set incorrectly")
 	s.T().Logf("Observed auth error in console output: %s", authOutput)
 
@@ -67,7 +67,7 @@ func (s *IntegrationTestSuite) TestConsoleCredentialRefresh() {
 	s.T().Log("Waiting for credential monitor to detect restored credentials...")
 	time.Sleep(15 * time.Second)
 
-	reconnectMarker := fmt.Sprintf("<ConMan> Connection to console [%s] opened", nodeID)
+	reconnectMarker := fmt.Sprintf("[Console %s connected at", nodeID)
 	reconnectOutput, err := s.readWebSocketUntil(wsConn, reconnectMarker, 2*time.Minute)
 	s.Require().NoError(err, "expected conman to reconnect after credentials were restored")
 	s.T().Logf("Observed reconnection marker in console output: %s", reconnectOutput)

--- a/test/interactive_test.go
+++ b/test/interactive_test.go
@@ -178,13 +178,15 @@ func (s *IntegrationTestSuite) TestConsoleInteractiveTail() {
 	}
 }
 
-func (s *IntegrationTestSuite) TestConsoleInteractiveReconnect() {
-	// Use existing console from SetupSuite
+func (s *IntegrationTestSuite) TestConsoleInteractiveNewNodeNoDisrupt() {
+	// Verify that adding a new SSH node does not disrupt an existing interactive session.
+	// Previously (conman era) adding a node caused conmand to restart, which briefly
+	// disconnected all existing consoles. With the Go SSH backend each node runs
+	// independently, so existing sessions must be unaffected.
 	console := consoleFixtures["ssh-password"]
 	existingNodeID := console.nodeID
 	promptTimeout := 90 * time.Second
 
-	// Connect to interactive console
 	wsConn, resp, err := s.connectInteractiveConsole(existingNodeID, console.prompt, promptTimeout)
 	s.Require().NoError(err)
 	defer func() {
@@ -196,25 +198,18 @@ func (s *IntegrationTestSuite) TestConsoleInteractiveReconnect() {
 		}
 	}()
 
-	// Run hostname command and validate console is working before triggering reconnection
-	s.T().Log("Running initial hostname command to verify console is working")
+	// Verify the existing console is working before adding a new node.
 	err = wsConn.WriteMessage(websocket.TextMessage, []byte("hostname\r"))
 	s.Require().NoError(err, "Error sending hostname command")
-
 	expectedHostLine := existingNodeID + "\r\n"
 	hostnameOutput, err := s.readWebSocketUntil(wsConn, expectedHostLine, promptTimeout)
-	s.Require().NoError(err, "Expected hostname output from console")
-	s.Require().Contains(hostnameOutput, expectedHostLine, "Expected hostname in output")
-	s.Require().NotContains(hostnameOutput, "[Reconnecting", "Console should not be reconnecting initially")
-	s.Require().NotContains(hostnameOutput, "Connection refused", "Console should be connected without errors")
+	s.Require().NoError(err, "Expected hostname output before new node added")
+	s.Require().Contains(hostnameOutput, expectedHostLine)
 	s.T().Logf("Initial hostname output: %s", hostnameOutput)
 
-	// Give the console a moment to stabilize
-	time.Sleep(2 * time.Second)
-
-	// Add a new node to trigger conmand restart
+	// Add a new SSH node.
 	newNodeID := "x0c0s10b0"
-	s.T().Logf("Adding new node %s to trigger conmand restart", newNodeID)
+	s.T().Logf("Adding new node %s", newNodeID)
 
 	authConfig := defaultAuthConfig
 	rfContainer, err := startRedfishEmulator(context.Background(), s.rfNetwork.Name, newNodeID, "ssh", &authConfig)
@@ -247,9 +242,7 @@ func (s *IntegrationTestSuite) TestConsoleInteractiveReconnect() {
 	})
 	s.Require().NoError(err, "failed to register new Redfish endpoint")
 
-	// Clean up the Redfish endpoint at the end to avoid interfering with other tests
 	defer func() {
-		s.T().Logf("Removing Redfish endpoint %s", newNodeID)
 		smdAPIURL, err := getSMDAPIURL(context.Background(), s.containers["smd"])
 		if err != nil {
 			s.T().Errorf("Warning: failed to get SMD API URL: %v", err)
@@ -260,38 +253,20 @@ func (s *IntegrationTestSuite) TestConsoleInteractiveReconnect() {
 		}
 	}()
 
-	// Verify reconnect messages appear
-	s.T().Log("Waiting for reconnection messages")
-	reconnectingMsg := fmt.Sprintf("[Reconnecting to %s", existingNodeID)
-	output, err := s.readWebSocketUntil(wsConn, reconnectingMsg, 2*time.Minute)
-	s.Require().NoError(err, "Expected reconnecting message")
-	s.Require().Contains(output, reconnectingMsg, "Expected reconnecting message in output")
-	s.T().Logf("Saw reconnecting message: %s", output)
+	// Wait for remote-console to discover the new node.
+	s.Require().NoError(s.waitForConsoleID(newNodeID, 3*time.Minute), "remote-console did not detect new console")
+	s.T().Logf("New node %s is visible in remote-console", newNodeID)
 
-	// Wait for ConMan connection banner to confirm successful reconnection
-	conmanConnectedMsg := fmt.Sprintf("<ConMan> Connection to console [%s] opened", existingNodeID)
-	output, err = s.readWebSocketUntil(wsConn, conmanConnectedMsg, 2*time.Minute)
-	s.Require().NoError(err, "Expected ConMan connection banner")
-	s.Require().Contains(output, conmanConnectedMsg, "Expected ConMan connection banner in output")
-	s.T().Logf("Saw ConMan connection banner: %s", output)
-
-	// Wait for console prompt to appear after reconnection
-	s.T().Log("Waiting for console prompt after reconnection")
-	_, err = s.waitForConsolePrompt(wsConn, ":~$ ", promptTimeout)
-	s.Require().NoError(err, "Expected console prompt after reconnection")
-	s.T().Log("Console prompt received after reconnection")
-
-	// Rerun hostname command to verify reconnection worked
-	s.T().Log("Running hostname command after reconnection")
+	// The existing session must still be alive and functional — no disconnect markers,
+	// no reconnect banners.
 	err = wsConn.WriteMessage(websocket.TextMessage, []byte("hostname\r"))
-	s.Require().NoError(err, "Error sending hostname command after reconnect")
-
+	s.Require().NoError(err, "Error sending hostname command after new node added")
 	hostnameOutput2, err := s.readWebSocketUntil(wsConn, expectedHostLine, promptTimeout)
-	s.Require().NoError(err, "Expected hostname output after reconnection")
-	s.Require().Contains(hostnameOutput2, expectedHostLine, "Expected hostname in output after reconnection")
-	s.T().Logf("Hostname output after reconnection: %s", hostnameOutput2)
-
-	s.T().Log("Reconnection test completed successfully")
+	s.Require().NoError(err, "Expected hostname output after new node added")
+	s.Require().Contains(hostnameOutput2, expectedHostLine, "Expected hostname in output after new node added")
+	s.Require().NotContains(hostnameOutput2, fmt.Sprintf("[Console %s disconnected", existingNodeID),
+		"Existing session must not have disconnected when a new node was added")
+	s.T().Logf("Existing session still alive after new node added: %s", hostnameOutput2)
 }
 
 func (s *IntegrationTestSuite) TestConsoleInteractiveClientClose() {

--- a/test/tail_test.go
+++ b/test/tail_test.go
@@ -351,19 +351,19 @@ func (s *IntegrationTestSuite) TestConsoleTailLinesFollow() {
 }
 
 func (s *IntegrationTestSuite) TestConsoleTailEntryCommand() {
-	// Test that the entry command is executed when connecting to the console
+	// Test that the entry command is executed when connecting to the console.
+	// x0c0s0b0n0 connects to the same SSH server as the ssh-password fixture (x0c0s0b0),
+	// so we broadcast via that container's broadcast.sh the same way other SSH fixtures do.
 	console := consoleFixture{
 		name:           "ssh-entry-cmd",
 		nodeID:         "x0c0s0b0n0",
-		containerKey:   "remote-console",
+		containerKey:   "ssh-password",
 		username:       "ADMIN",
 		password:       "ADMIN",
 		readyLogMarker: "Welcome to OpenSSH Server",
 		prompt:         ":~$ ",
-		// We use 'expect' here as with the entry command there may not be a pty that
-		// broadcast.sh can write to, so we spawn conman in expect to echo a message
 		broadcastCmd: func(msg string) []string {
-			return []string{"expect", "-c", fmt.Sprintf("spawn conman x0c0s0b0n0; expect \"password:\"; expect \":~$ \"; send \"echo '%s'\\r\"; send \"&.\\r\"; expect eof", msg)}
+			return []string{"broadcast.sh", msg}
 		},
 	}
 


### PR DESCRIPTION
Route interactive consoles through the shared backend interface: IPMI through ConMan and SSH through the in-process manager. Update existing integration expectations and keep credential change detection based on the complete inventory after subset reads.