### PR TITLE
feat(ssh): apply inventory without credential reads

### DIFF
--- a/cmd/remote-console/service.go
+++ b/cmd/remote-console/service.go
@@ -51,12 +51,12 @@ type LogsService interface {
 	AggregateFiles(consoleLogsPath string, nodes map[string]*nodes.NodeConsoleInfo)
 }
 
-// SSHConsoleService defines the management interface for the SSH console manager.
-// Interactive access (Attach/Detach/Write) flows through the console.SSHManager
-// interface, which is passed directly to console.SetupRoutes.
+// SSHConsoleService defines the management interface for the SSH console
+// manager. Interactive access (Attach/Detach/Write) does not go through here —
+// the concrete *ssh.SSHConsoleManager is passed to console.SetupRoutes, which
+// uses it directly.
 type SSHConsoleService interface {
-	UpdateNodes(ctx context.Context, sshNodes map[string]*nodes.NodeConsoleInfo,
-		passwords map[string]compcreds.CompCredentials) error
+	UpdateNodes(ctx context.Context, sshNodes map[string]*nodes.NodeConsoleInfo) error
 	UpdateCredentials(passwords map[string]compcreds.CompCredentials)
 	ReopenLogs()
 }
@@ -116,16 +116,37 @@ func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpC
 				currentNodes := nodes.CurrentNodes()
 				passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(currentNodes), 15, 10)
 				if err != nil {
-					slog.Error("Failed to fetch credentials for updated nodes", "error", err)
+					// passwords holds whatever the final attempt returned: possibly
+					// nil, possibly a partial map. An absent entry is then
+					// indistinguishable from a node that legitimately has no password
+					// and uses key auth, so neither consumer can read this map as the
+					// full picture.
+					//
+					// Skip the conman reconfigure — it interpolates credentials
+					// straight into conman.conf, and rewriting that from a partial map
+					// before SignalConmanTERM would drop working IPMI consoles. Apply
+					// the SSH node changes without credentials, so removed nodes
+					// still stop and added nodes still start while every existing
+					// node keeps the credentials it already has.
+					//
+					// This only catches the failed fetch. A fetch that exhausts its
+					// retries and returns a partial map with a nil error takes the
+					// branch below and reconfigures from incomplete credentials.
+					slog.Error("Failed to fetch credentials for updated nodes; skipping conman reconfigure, applying SSH node changes without credentials", "error", err)
+					if err := sshService.UpdateNodes(ctx, filterSSHNodes(currentNodes)); err != nil {
+						slog.Error("Failed to update SSH console nodes", "error", err)
+					}
 				} else {
 					// Regenerate conman config with the new node list and credentials.
 					if _, err := conmanService.ConfigureConman(filterIPMINodes(currentNodes), passwords); err != nil {
 						slog.Error("Failed to reconfigure conman", "error", err)
 					}
-					// Update SSH nodes with current topology and credentials.
-					if err := sshService.UpdateNodes(ctx, filterSSHNodes(currentNodes), passwords); err != nil {
+					// Update SSH membership before delivering the credentials that
+					// were fetched for the current node set.
+					if err := sshService.UpdateNodes(ctx, filterSSHNodes(currentNodes)); err != nil {
 						slog.Error("Failed to update SSH console manager", "error", err)
 					}
+					sshService.UpdateCredentials(passwords)
 				}
 
 				// Restart conman to pick up the new config.
@@ -170,6 +191,11 @@ func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig,
 				currentNodes := nodes.CurrentNodes()
 				passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(currentNodes), 3, 5)
 				if err != nil {
+					// Same partial-map ambiguity as the node watch loop, but here
+					// skipping outright is the whole answer: no node joined or left,
+					// so there is no node change to apply and every node keeps
+					// running on the credentials it already has until a later fetch
+					// succeeds.
 					slog.Error("Failed to fetch updated credentials", "error", err)
 				} else {
 					// Regenerate conman config so IPMI nodes pick up the new credentials.
@@ -370,10 +396,18 @@ func runService(config remoteConsoleConfig) error {
 	initialSSHNodes := filterSSHNodes(nodes.CurrentNodes())
 	if len(initialSSHNodes) > 0 {
 		initialXNames := filterXNames(initialSSHNodes)
-		if passwords, err := credsService.GetPasswordsWithRetries(serviceCtx, initialXNames, 15, 10); err != nil {
-			slog.Warn("Failed to fetch initial SSH credentials", "error", err)
-		} else if err := sshManager.UpdateNodes(serviceCtx, initialSSHNodes, passwords); err != nil {
+		passwords, err := credsService.GetPasswordsWithRetries(serviceCtx, initialXNames, 15, 10)
+		if err != nil {
+			// Start the nodes anyway. watchForNodesUpdates only reconfigures when
+			// inventory actually changes, so bailing out here would leave every
+			// SSH console dead until something in SMD happened to change.
+			slog.Warn("Failed to fetch initial SSH credentials, starting nodes without them", "error", err)
+		}
+		if err := sshManager.UpdateNodes(serviceCtx, initialSSHNodes); err != nil {
 			slog.Error("Failed initial SSH manager node update", "error", err)
+		}
+		if err == nil {
+			sshManager.UpdateCredentials(passwords)
 		}
 	}
 

--- a/internal/ssh/concurrent_test.go
+++ b/internal/ssh/concurrent_test.go
@@ -82,9 +82,7 @@ func TestSSHConsoleManagerConcurrent(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
-		t.Fatalf("initial UpdateNodes: %v", err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
 	// Wait until all nodes are registered (Attach succeeds) before starting workers.
 	deadline := time.Now().Add(30 * time.Second)
@@ -213,15 +211,17 @@ func TestSSHConsoleManagerConcurrent(t *testing.T) {
 				}
 			}
 			subMap := makeNodeMap(subset)
-			if err := manager.UpdateNodes(ctx, subMap, makePasswords(subset)); err != nil {
+			if err := manager.UpdateNodes(ctx, subMap); err != nil {
 				t.Errorf("UpdateNodes (subset): %v", err)
 			}
+			manager.UpdateCredentials(makePasswords(subset))
 			time.Sleep(20 * time.Millisecond)
 
 			// Restore the full set.
-			if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
+			if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
 				t.Errorf("UpdateNodes (full): %v", err)
 			}
+			manager.UpdateCredentials(passwords)
 			time.Sleep(20 * time.Millisecond)
 		}
 	}()

--- a/internal/ssh/console.go
+++ b/internal/ssh/console.go
@@ -177,8 +177,8 @@ func jitter(d time.Duration) time.Duration {
 // when the node leaves inventory, which makes the manager the single authority
 // on node lifetime. Run must not decide to stop on its own: the manager would
 // keep the node in its map with no goroutine behind it, so Attach would hand
-// back a channel that never delivers and no later UpdateNodes would revive it
-// (the node still "exists" and its parameters are unchanged).
+// back a channel that never delivers and no later update would revive it (the
+// node still "exists" and its parameters are unchanged).
 func (c *SSHConsole) Run(ctx context.Context) {
 	var err error
 	c.logFile, err = os.OpenFile(c.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)

--- a/internal/ssh/console_test.go
+++ b/internal/ssh/console_test.go
@@ -12,7 +12,6 @@ import (
 	"testing"
 	"time"
 
-	compcredentials "github.com/Cray-HPE/hms-compcredentials"
 	gossh "golang.org/x/crypto/ssh"
 
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
@@ -34,9 +33,7 @@ func TestSSHConsoleReconnect(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
-		t.Fatal(err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
 	// Attach before the first connect so we capture the initial connected marker.
 	clientCh, err := manager.Attach(id, "reconnect-client")
@@ -75,9 +72,7 @@ func TestSSHConsoleFanOut(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
-		t.Fatal(err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
 	const numClients = 5
 	clients := make([]<-chan []byte, numClients)
@@ -145,9 +140,7 @@ func TestSSHConsoleDataFlow(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
-		t.Fatal(err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
 	clientCh, err := manager.Attach(id, "data-client")
 	if err != nil {
@@ -201,9 +194,7 @@ func TestSSHConsoleLifecycle(t *testing.T) {
 
 	goroutinesBefore := runtime.NumGoroutine()
 
-	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
-		t.Fatal(err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
 	// Wait for the node to connect.
 	<-sessionCh
@@ -211,7 +202,7 @@ func TestSSHConsoleLifecycle(t *testing.T) {
 
 	// Remove the node. The manager is the sole authority on node lifetime, so
 	// cancelling through UpdateNodes must be enough to stop Run.
-	if err := manager.UpdateNodes(ctx, map[string]*nodes.NodeConsoleInfo{}, map[string]compcredentials.CompCredentials{}); err != nil {
+	if err := manager.UpdateNodes(ctx, map[string]*nodes.NodeConsoleInfo{}); err != nil {
 		t.Fatal(err)
 	}
 
@@ -254,9 +245,7 @@ func TestSlowClientGetsDropNotice(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
-		t.Fatal(err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
 	clientCh, err := manager.Attach(id, "slow-client")
 	if err != nil {

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -33,11 +33,11 @@ type SSHConsoleManager struct {
 	consoles   map[string]*SSHConsole
 	// cancels maps nodeID to the cancel func for that console's Run goroutine.
 	cancels map[string]context.CancelFunc
+	running sync.WaitGroup
 }
 
-// NewSSHConsoleManager creates a new manager. keyPath is the SSH private key
-// path (may be empty if all nodes use password auth). logsPath is the directory
-// where per-console console log files are written.
+// NewSSHConsoleManager creates a manager from validated configuration. keyPath may be empty when
+// all nodes use password authentication. logsPath stores per-console console logs.
 func NewSSHConsoleManager(cfg SSHConfig, keyPath, logsPath string) *SSHConsoleManager {
 	return &SSHConsoleManager{
 		cfg:      cfg,
@@ -46,6 +46,12 @@ func NewSSHConsoleManager(cfg SSHConfig, keyPath, logsPath string) *SSHConsoleMa
 		consoles: make(map[string]*SSHConsole),
 		cancels:  make(map[string]context.CancelFunc),
 	}
+}
+
+// Wait blocks until all console goroutines have stopped. The caller must first
+// cancel the context passed to UpdateNodes or remove every managed console.
+func (m *SSHConsoleManager) Wait() {
+	m.running.Wait()
 }
 
 // logPath returns the log file path for a console.
@@ -65,15 +71,13 @@ func credsChanged(a, b compcredentials.CompCredentials) bool {
 	return a.Username != b.Username || a.Password != b.Password
 }
 
-// UpdateNodes diffs the provided SSH console map against the currently active set.
-// New nodes are started, removed nodes are cancelled, changed nodes are restarted,
-// and nodes with only credential changes get UpdateCreds called.
-// ctx must be the long-lived service context — console goroutines run until it is
-// cancelled or the console is explicitly stopped.
+// UpdateNodes syncs managed consoles with the provided SSH console set. It starts new nodes, stops
+// removed nodes, and restarts consoles when connection settings change. Existing nodes retain
+// their credentials. ctx controls console lifetime. New nodes use key authentication until
+// UpdateCredentials supplies a password.
 func (m *SSHConsoleManager) UpdateNodes(
 	ctx context.Context,
 	sshNodes map[string]*nodes.NodeConsoleInfo,
-	passwords map[string]compcredentials.CompCredentials,
 ) error {
 	m.consolesMu.Lock()
 	defer m.consolesMu.Unlock()
@@ -89,27 +93,19 @@ func (m *SSHConsoleManager) UpdateNodes(
 	}
 
 	for nodeID, info := range sshNodes {
-		creds := passwords[nodeID]
-
 		existing, exists := m.consoles[nodeID]
 		if !exists {
-			// New console.
-			m.startConsole(ctx, nodeID, info, creds)
+			m.startConsole(ctx, nodeID, info, compcredentials.CompCredentials{})
 			continue
 		}
 
 		if nodeChanged(existing.info, info) {
-			// Connection parameters changed — restart.
+			// Connection parameters changed — restart with the credentials the
+			// console is already using.
 			slog.Info("SSH console console parameters changed, restarting", "nodeID", nodeID)
+			creds := existing.currentCreds()
 			m.cancels[nodeID]()
 			m.startConsole(ctx, nodeID, info, creds)
-			continue
-		}
-
-		if credsChanged(existing.creds, creds) {
-			// Credentials only — reconnect in place without full restart.
-			slog.Info("SSH console console credentials changed, reconnecting", "nodeID", nodeID)
-			existing.UpdateCreds(creds)
 		}
 	}
 
@@ -124,11 +120,15 @@ func (m *SSHConsoleManager) startConsole(ctx context.Context, nodeID string, inf
 	m.consoles[nodeID] = console
 	m.cancels[nodeID] = nodeCancel
 	slog.Info("Starting SSH console console", "nodeID", nodeID, "host", info.ConnectionHost)
-	go console.Run(nodeCtx)
+	m.running.Add(1)
+	go func() {
+		defer m.running.Done()
+		console.Run(nodeCtx)
+	}()
 }
 
-// UpdateCredentials updates credentials for nodes whose passwords have changed.
-// Nodes that changed connection info should use UpdateNodes instead.
+// UpdateCredentials updates credentials for managed nodes present in passwords.
+// Nodes absent from passwords retain their current credentials.
 func (m *SSHConsoleManager) UpdateCredentials(passwords map[string]compcredentials.CompCredentials) {
 	m.consolesMu.RLock()
 	type pending struct {
@@ -138,7 +138,7 @@ func (m *SSHConsoleManager) UpdateCredentials(passwords map[string]compcredentia
 	var updates []pending
 	for nodeID, console := range m.consoles {
 		if creds, ok := passwords[nodeID]; ok {
-			if credsChanged(console.creds, creds) {
+			if credsChanged(console.currentCreds(), creds) {
 				updates = append(updates, pending{console, creds})
 			}
 		}

--- a/internal/ssh/manager_test.go
+++ b/internal/ssh/manager_test.go
@@ -1,0 +1,199 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package ssh_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	compcredentials "github.com/Cray-HPE/hms-compcredentials"
+	gossh "golang.org/x/crypto/ssh"
+
+	"github.com/OpenCHAMI/remote-console/internal/nodes"
+	"github.com/OpenCHAMI/remote-console/internal/ssh"
+)
+
+// deadAddr returns an unused local address so connections fail immediately.
+func deadAddr(t *testing.T) string {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := ln.Addr().String()
+	if err := ln.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return addr
+}
+
+// TestWriteWhileDisconnectedReportsNotConnected verifies disconnected writes report no bytes.
+// This prevents discarded input from appearing delivered. ErrNotConnected remains distinct from
+// unmanaged node errors because reconnects are temporary.
+func TestWriteWhileDisconnectedReportsNotConnected(t *testing.T) {
+	id, nodeMap, passwords := singleNode(t, deadAddr(t))
+
+	manager := newManager(t, t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	startNodes(t, manager, ctx, nodeMap, passwords)
+
+	n, err := manager.Write(id, []byte("into the void\n"))
+	if !errors.Is(err, ssh.ErrNotConnected) {
+		t.Fatalf("Write to a disconnected node = (%d, %v), want ErrNotConnected", n, err)
+	}
+	if n != 0 {
+		t.Errorf("Write to a disconnected node reported %d bytes written, want 0", n)
+	}
+
+	if _, err := manager.Write("no-such-node", []byte("x")); err == nil {
+		t.Fatal("Write to an unknown node succeeded")
+	} else if errors.Is(err, ssh.ErrNotConnected) {
+		t.Error("Write to an unknown node returned ErrNotConnected; a missing node is permanent, not a reconnect")
+	}
+}
+
+// waitForBytes reads until the expected session input arrives or the timeout expires.
+func waitForBytes(t *testing.T, sess *sshSession, want string, timeout time.Duration) {
+	t.Helper()
+	timer := time.NewTimer(timeout)
+	defer timer.Stop()
+	var got strings.Builder
+	for {
+		select {
+		case data := <-sess.recv:
+			got.Write(data)
+			if strings.Contains(got.String(), want) {
+				return
+			}
+		case <-timer.C:
+			t.Fatalf("timeout waiting for %q on session; got %q", want, got.String())
+		}
+	}
+}
+
+// TestUpdateNodesPreservesCredentials covers the case where the service's
+// credential fetch failed and it falls back to a credential-preserving
+// update. A
+// healthy node must keep running on the credentials it already has. Applying
+// the empty password would trigger UpdateCreds, drop the connection, and then
+// fall through to key auth, which is not what this node uses.
+func TestUpdateNodesPreservesCredentials(t *testing.T) {
+	sessionCh := make(chan *sshSession)
+	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
+	id, nodeMap, passwords := singleNode(t, srv.addr())
+
+	manager := newManager(t, t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	startNodes(t, manager, ctx, nodeMap, passwords)
+
+	// The connected marker confirms stdin is ready before the first write.
+	clientCh, err := manager.Attach(id, "creds-client")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Detach(id, "creds-client")
+
+	sess := <-sessionCh
+	waitForMarker(t, clientCh, "[Console "+id+" connected at", 15*time.Second)
+
+	if _, err := manager.Write(id, []byte("before\n")); err != nil {
+		t.Fatalf("write before update: %v", err)
+	}
+	waitForBytes(t, sess, "before", 15*time.Second)
+
+	// Same node set, credentials incomplete — what the service does when the
+	// fetch fails.
+	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
+		t.Fatal(err)
+	}
+
+	// The original session must still be live. If the credentials had been
+	// cleared, UpdateCreds would have torn this connection down.
+	select {
+	case <-sessionCh:
+		t.Fatal("node reconnected after a credential-preserving update; existing credentials were not preserved")
+	case <-time.After(2 * time.Second):
+	}
+
+	if _, err := manager.Write(id, []byte("after\n")); err != nil {
+		t.Fatalf("write after update: %v", err)
+	}
+	waitForBytes(t, sess, "after", 15*time.Second)
+}
+
+// TestUpdateNodesAddsAndRemovesNodes verifies that a credential-preserving update
+// still adds and removes nodes. Before this, a failed credential fetch skipped
+// the SSH update entirely, so a node removed from inventory kept its console
+// running and a newly added node never started.
+func TestUpdateNodesAddsAndRemovesNodes(t *testing.T) {
+	srv := newSSHServer(t, func(ch gossh.Channel) { _ = ch.Close() })
+	id, nodeMap, _ := singleNode(t, srv.addr())
+
+	manager := newManager(t, t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Add. The node must be registered so a later UpdateCredentials can reach it.
+	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Attach(id, "probe"); err != nil {
+		t.Fatalf("node was not registered by a credential-preserving update: %v", err)
+	}
+	manager.Detach(id, "probe")
+
+	// Remove.
+	if err := manager.UpdateNodes(ctx, map[string]*nodes.NodeConsoleInfo{}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Attach(id, "probe"); err == nil {
+		t.Fatal("node still registered after removal via a credential-less update")
+	}
+}
+
+// TestUpdateCredentialsIgnoresAbsentNodes verifies that a credential update only
+// affects nodes present in the supplied map. An absent entry may reflect a
+// partial fetch and must not clear working credentials.
+func TestUpdateCredentialsIgnoresAbsentNodes(t *testing.T) {
+	sessionCh := make(chan *sshSession)
+	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
+	id, nodeMap, passwords := singleNode(t, srv.addr())
+
+	manager := newManager(t, t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	startNodes(t, manager, ctx, nodeMap, passwords)
+
+	clientCh, err := manager.Attach(id, "absent-client")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer manager.Detach(id, "absent-client")
+
+	sess := <-sessionCh
+	waitForMarker(t, clientCh, "[Console "+id+" connected at", 15*time.Second)
+
+	manager.UpdateCredentials(map[string]compcredentials.CompCredentials{})
+
+	select {
+	case <-sessionCh:
+		t.Fatal("node reconnected after an update that did not mention it")
+	case <-time.After(2 * time.Second):
+	}
+
+	if _, err := manager.Write(id, []byte("still-here\n")); err != nil {
+		t.Fatalf("write after the empty credential update: %v", err)
+	}
+	waitForBytes(t, sess, "still-here", 15*time.Second)
+}

--- a/internal/ssh/scale_test.go
+++ b/internal/ssh/scale_test.go
@@ -79,9 +79,7 @@ func TestSSHConsoleManagerScale(t *testing.T) {
 
 	goroutinesBefore := runtime.NumGoroutine()
 
-	if err := manager.UpdateNodes(ctx, nodeMap, passwords); err != nil {
-		t.Fatalf("UpdateNodes: %v", err)
-	}
+	startNodes(t, manager, ctx, nodeMap, passwords)
 
 	// Wait until all nodes have established a shell session on the server.
 	t.Logf("Waiting for %d nodes to connect (timeout %s)…", scaleNodeCount, scaleConnTimeout)

--- a/internal/ssh/server_test.go
+++ b/internal/ssh/server_test.go
@@ -8,6 +8,7 @@ package ssh_test
 // concurrent, and node-behaviour tests.
 
 import (
+	"context"
 	"crypto/ed25519"
 	"crypto/rand"
 	"fmt"
@@ -243,6 +244,21 @@ func singleNode(t *testing.T, addr string) (id string, nodeMap map[string]*nodes
 	return
 }
 
+// startNodes follows service ordering by registering membership before delivering credentials.
+func startNodes(
+	t *testing.T,
+	manager *ssh.SSHConsoleManager,
+	ctx context.Context,
+	nodeMap map[string]*nodes.NodeConsoleInfo,
+	passwords map[string]compcredentials.CompCredentials,
+) {
+	t.Helper()
+	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
+		t.Fatalf("UpdateNodes: %v", err)
+	}
+	manager.UpdateCredentials(passwords)
+}
+
 // makePasswordsWith builds a credential map assigning the same password to
 // every id.
 func makePasswordsWith(ids []string, password string) map[string]compcredentials.CompCredentials {
@@ -261,7 +277,9 @@ func newManager(t *testing.T, logsDir string) *ssh.SSHConsoleManager {
 	cfg.TCPKeepAlive = 0
 	cfg.ReconnectMinInterval = 250 * time.Millisecond
 	cfg.ReconnectMaxInterval = 1 * time.Second
-	return ssh.NewSSHConsoleManager(cfg, "", logsDir)
+	manager := ssh.NewSSHConsoleManager(cfg, "", logsDir)
+	t.Cleanup(manager.Wait)
+	return manager
 }
 
 // waitForMarker reads from ch until the accumulated output contains marker or


### PR DESCRIPTION
Update SSH membership independently of credential reads while preserving credentials on existing consoles. Apply only credential entries that are present so partial responses cannot clear working authentication.