### PR TITLE
feat(ssh): wait for provisioned credentials

### DIFF
--- a/cmd/remote-console/service.go
+++ b/cmd/remote-console/service.go
@@ -92,10 +92,13 @@ func filterXNames(sshNodes map[string]*nodes.NodeConsoleInfo) []string {
 	return xnames
 }
 
-// Watch for node updates and signal conman and log rotation as needed
+// Watch for node updates and signal conman and log rotation as needed.
+//
+// This loop decides membership only. Credentials belong to watchForCredUpdates,
+// which retries delivery for the current SSH nodes on every tick.
 func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpClient *http.Client,
 	conmanService ConmanService, logsService LogsService,
-	credsService CredsService, sshService SSHConsoleService) {
+	sshService SSHConsoleService) {
 	// ConMan writes console files in a conman subdirectory.
 	consoleLogsPath := filepath.Join(config.Log.ConsoleLogsBasePath, "conman")
 
@@ -114,42 +117,12 @@ func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpC
 				slog.Info("Node changes detected, reconfiguring services")
 
 				currentNodes := nodes.CurrentNodes()
-				passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(currentNodes), 15, 10)
-				if err != nil {
-					// passwords holds whatever the final attempt returned: possibly
-					// nil, possibly a partial map. An absent entry is then
-					// indistinguishable from a node that legitimately has no password
-					// and uses key auth, so neither consumer can read this map as the
-					// full picture.
-					//
-					// Skip the conman reconfigure — it interpolates credentials
-					// straight into conman.conf, and rewriting that from a partial map
-					// before SignalConmanTERM would drop working IPMI consoles. Apply
-					// the SSH node changes without credentials, so removed nodes
-					// still stop and added nodes still start while every existing
-					// node keeps the credentials it already has.
-					//
-					// This only catches the failed fetch. A fetch that exhausts its
-					// retries and returns a partial map with a nil error takes the
-					// branch below and reconfigures from incomplete credentials.
-					slog.Error("Failed to fetch credentials for updated nodes; skipping conman reconfigure, applying SSH node changes without credentials", "error", err)
-					if err := sshService.UpdateNodes(ctx, filterSSHNodes(currentNodes)); err != nil {
-						slog.Error("Failed to update SSH console nodes", "error", err)
-					}
-				} else {
-					// Regenerate conman config with the new node list and credentials.
-					if _, err := conmanService.ConfigureConman(filterIPMINodes(currentNodes), passwords); err != nil {
-						slog.Error("Failed to reconfigure conman", "error", err)
-					}
-					// Update SSH membership before delivering the credentials that
-					// were fetched for the current node set.
-					if err := sshService.UpdateNodes(ctx, filterSSHNodes(currentNodes)); err != nil {
-						slog.Error("Failed to update SSH console manager", "error", err)
-					}
-					sshService.UpdateCredentials(passwords)
+
+				sshNodes := filterSSHNodes(currentNodes)
+				if err := sshService.UpdateNodes(ctx, sshNodes); err != nil {
+					slog.Error("Failed to update SSH console nodes", "error", err)
 				}
 
-				// Restart conman to pick up the new config.
 				if err := conmanService.SignalConmanTERM(); err != nil {
 					slog.Error("Failed to signal conman with SIGTERM", "error", err)
 				}
@@ -168,7 +141,11 @@ func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpC
 	}
 }
 
-// Watch for credential updates and signal conman and SSH manager as needed
+// Watch for credential updates and signal conman and SSH manager as needed.
+//
+// This loop is the sole owner of credential delivery to the SSH manager. It
+// fetches on every tick so a node added after startup receives its entry even
+// when nothing in Vault changed.
 func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig,
 	credsService CredsService, conmanService ConmanService, sshService SSHConsoleService) {
 	ticker := time.NewTicker(time.Duration(config.CredsMonitorInterval) * time.Second)
@@ -185,28 +162,28 @@ func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig,
 				slog.Error("Failed to check for credential updates", "error", err)
 			}
 
-			if changed {
-				slog.Info("Credential changes detected, reconfiguring services")
-
-				currentNodes := nodes.CurrentNodes()
-				passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(currentNodes), 3, 5)
-				if err != nil {
-					// Same partial-map ambiguity as the node watch loop, but here
-					// skipping outright is the whole answer: no node joined or left,
-					// so there is no node change to apply and every node keeps
-					// running on the credentials it already has until a later fetch
-					// succeeds.
-					slog.Error("Failed to fetch updated credentials", "error", err)
-				} else {
-					// Regenerate conman config so IPMI nodes pick up the new credentials.
-					if _, err := conmanService.ConfigureConman(filterIPMINodes(currentNodes), passwords); err != nil {
-						slog.Error("Failed to reconfigure conman with updated credentials", "error", err)
-					}
-					// Push updated credentials to SSH nodes.
-					sshService.UpdateCredentials(passwords)
+			// Only the SSH manager needs the passwords here. conman picks the
+			// new ones up when runConman rebuilds conman.conf after the SIGTERM
+			// below. A regular tick makes one attempt; a reported Vault change
+			// gets the existing retry budget.
+			sshNodes := filterSSHNodes(nodes.CurrentNodes())
+			if len(sshNodes) > 0 {
+				tries, wait := 1, 0
+				if changed {
+					tries, wait = 3, 5
 				}
+				passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(sshNodes), tries, wait)
+				if err != nil {
+					// Whatever came back is still worth applying. Absent node
+					// IDs are left alone, so a partial map only moves nodes
+					// forward onto credentials that arrived.
+					slog.Error("Failed to fetch updated credentials", "error", err)
+				}
+				sshService.UpdateCredentials(passwords)
+			}
 
-				// Always restart conman regardless of config update outcome.
+			if changed {
+				slog.Info("Credential changes detected, restarting conman")
 				if err := conmanService.SignalConmanTERM(); err != nil {
 					slog.Error("Failed to signal conman with SIGTERM", "error", err)
 				}
@@ -392,30 +369,11 @@ func runService(config remoteConsoleConfig) error {
 	// Create the SSH console manager.
 	sshManager := ssh.NewSSHConsoleManager(config.SSH, config.Creds.SshConsoleKeyPath, consoleLogsPath)
 
-	// Seed SSH nodes immediately — watchForNodesUpdates only fires after the first tick.
-	initialSSHNodes := filterSSHNodes(nodes.CurrentNodes())
-	if len(initialSSHNodes) > 0 {
-		initialXNames := filterXNames(initialSSHNodes)
-		passwords, err := credsService.GetPasswordsWithRetries(serviceCtx, initialXNames, 15, 10)
-		if err != nil {
-			// Start the nodes anyway. watchForNodesUpdates only reconfigures when
-			// inventory actually changes, so bailing out here would leave every
-			// SSH console dead until something in SMD happened to change.
-			slog.Warn("Failed to fetch initial SSH credentials, starting nodes without them", "error", err)
-		}
-		if err := sshManager.UpdateNodes(serviceCtx, initialSSHNodes); err != nil {
-			slog.Error("Failed initial SSH manager node update", "error", err)
-		}
-		if err == nil {
-			sshManager.UpdateCredentials(passwords)
-		}
-	}
-
 	// goroutine for log rotation
 	go logRotate(serviceCtx, config, conmanService, logsService, sshManager)
 
 	// goroutine to watches for changes in console configuration
-	go watchForNodesUpdates(serviceCtx, config, smdHTTPClient, conmanService, logsService, credsService, sshManager)
+	go watchForNodesUpdates(serviceCtx, config, smdHTTPClient, conmanService, logsService, sshManager)
 
 	// goroutine to run conman
 	go runConman(serviceCtx, conmanService, credsService)

--- a/internal/ssh/auth_test.go
+++ b/internal/ssh/auth_test.go
@@ -1,0 +1,179 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package ssh
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	compcredentials "github.com/Cray-HPE/hms-compcredentials"
+	gossh "golang.org/x/crypto/ssh"
+)
+
+func writeTestPrivateKey(t *testing.T, path string) gossh.Signer {
+	t.Helper()
+
+	_, privateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := gossh.MarshalPrivateKey(privateKey, "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, pem.EncodeToMemory(block), 0600); err != nil {
+		t.Fatal(err)
+	}
+	signer, err := gossh.NewSignerFromKey(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return signer
+}
+
+func writeTestCertificate(t *testing.T, path string, key gossh.PublicKey) {
+	t.Helper()
+
+	_, caPrivateKey, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caSigner, err := gossh.NewSignerFromKey(caPrivateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cert := &gossh.Certificate{
+		Key:         key,
+		CertType:    gossh.UserCert,
+		KeyId:       "test",
+		ValidBefore: gossh.CertTimeInfinity,
+	}
+	if err := cert.SignCert(rand.Reader, caSigner); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, gossh.MarshalAuthorizedKey(cert), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBuildAuth(t *testing.T) {
+	t.Run("password takes priority", func(t *testing.T) {
+		console := &SSHConsole{nodeID: "node", keyPath: filepath.Join(t.TempDir(), "missing")}
+		methods, err := console.buildAuth(compcredentials.CompCredentials{Password: "password"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(methods) != 1 {
+			t.Fatalf("got %d auth methods, want 1", len(methods))
+		}
+	})
+
+	t.Run("missing key path", func(t *testing.T) {
+		console := &SSHConsole{nodeID: "node"}
+		_, err := console.buildAuth(compcredentials.CompCredentials{})
+		if err == nil || !strings.Contains(err.Error(), "no key path configured") {
+			t.Fatalf("got %v, want missing key path error", err)
+		}
+	})
+
+	t.Run("missing key file", func(t *testing.T) {
+		console := &SSHConsole{nodeID: "node", keyPath: filepath.Join(t.TempDir(), "missing")}
+		_, err := console.buildAuth(compcredentials.CompCredentials{})
+		if err == nil || !strings.Contains(err.Error(), "read SSH key") {
+			t.Fatalf("got %v, want key read error", err)
+		}
+	})
+
+	t.Run("invalid private key", func(t *testing.T) {
+		keyPath := filepath.Join(t.TempDir(), "console.key")
+		if err := os.WriteFile(keyPath, []byte("invalid"), 0600); err != nil {
+			t.Fatal(err)
+		}
+		console := &SSHConsole{nodeID: "node", keyPath: keyPath}
+		_, err := console.buildAuth(compcredentials.CompCredentials{})
+		if err == nil || !strings.Contains(err.Error(), "parse SSH private key") {
+			t.Fatalf("got %v, want private key parse error", err)
+		}
+	})
+
+	t.Run("key only", func(t *testing.T) {
+		keyPath := filepath.Join(t.TempDir(), "console.key")
+		writeTestPrivateKey(t, keyPath)
+		console := &SSHConsole{nodeID: "node", keyPath: keyPath}
+		methods, err := console.buildAuth(compcredentials.CompCredentials{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(methods) != 1 {
+			t.Fatalf("got %d auth methods, want 1", len(methods))
+		}
+	})
+
+	t.Run("invalid certificate", func(t *testing.T) {
+		keyPath := filepath.Join(t.TempDir(), "console.key")
+		writeTestPrivateKey(t, keyPath)
+		if err := os.WriteFile(keyPath+"-cert.pub", []byte("invalid"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		console := &SSHConsole{nodeID: "node", keyPath: keyPath}
+		_, err := console.buildAuth(compcredentials.CompCredentials{})
+		if err == nil || !strings.Contains(err.Error(), "parse SSH certificate") {
+			t.Fatalf("got %v, want certificate parse error", err)
+		}
+	})
+
+	t.Run("public key is not a certificate", func(t *testing.T) {
+		keyPath := filepath.Join(t.TempDir(), "console.key")
+		signer := writeTestPrivateKey(t, keyPath)
+		if err := os.WriteFile(keyPath+"-cert.pub", gossh.MarshalAuthorizedKey(signer.PublicKey()), 0644); err != nil {
+			t.Fatal(err)
+		}
+		console := &SSHConsole{nodeID: "node", keyPath: keyPath}
+		_, err := console.buildAuth(compcredentials.CompCredentials{})
+		if err == nil || !strings.Contains(err.Error(), "is not an SSH certificate") {
+			t.Fatalf("got %v, want certificate type error", err)
+		}
+	})
+
+	t.Run("certificate key mismatch", func(t *testing.T) {
+		keyPath := filepath.Join(t.TempDir(), "console.key")
+		writeTestPrivateKey(t, keyPath)
+		_, otherPrivateKey, err := ed25519.GenerateKey(rand.Reader)
+		if err != nil {
+			t.Fatal(err)
+		}
+		otherSigner, err := gossh.NewSignerFromKey(otherPrivateKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		writeTestCertificate(t, keyPath+"-cert.pub", otherSigner.PublicKey())
+
+		console := &SSHConsole{nodeID: "node", keyPath: keyPath}
+		_, err = console.buildAuth(compcredentials.CompCredentials{})
+		if err == nil || !strings.Contains(err.Error(), "create cert signer") {
+			t.Fatalf("got %v, want certificate signer error", err)
+		}
+	})
+
+	t.Run("certificate", func(t *testing.T) {
+		keyPath := filepath.Join(t.TempDir(), "console.key")
+		signer := writeTestPrivateKey(t, keyPath)
+		writeTestCertificate(t, keyPath+"-cert.pub", signer.PublicKey())
+
+		console := &SSHConsole{nodeID: "node", keyPath: keyPath}
+		methods, err := console.buildAuth(compcredentials.CompCredentials{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(methods) != 1 {
+			t.Fatalf("got %d auth methods, want 1", len(methods))
+		}
+	})
+}

--- a/internal/ssh/concurrent_test.go
+++ b/internal/ssh/concurrent_test.go
@@ -22,20 +22,9 @@ import (
 )
 
 // TestSSHConsoleManagerConcurrent exercises concurrent access to SSHConsoleManager
-// and SSHConsole. Run with -race to catch synchronisation bugs:
+// and SSHConsole.
 //
 //	go test -race -v -run TestSSHConsoleManagerConcurrent ./internal/ssh/ -timeout 60s
-//
-// Workers run simultaneously for concurrentDuration, each hammering a different
-// surface area:
-//
-//	attachWorker  – Attach, drain a few bytes, Detach (stresses clientsMu)
-//	writeWorker   – Write to random nodes while connections may be tearing down
-//	                (stresses connMu)
-//	credsWorker   – UpdateCredentials in a tight loop (stresses credsMu + connMu)
-//	rotateWorker  – ReopenLogs repeatedly (stresses reopenLogCh vs broadcast)
-//	updateWorker  – UpdateNodes with a shifting node set (stresses consolesMu vs
-//	                everything else)
 const (
 	concurrentNodes    = 100
 	concurrentWorkers  = 20
@@ -108,12 +97,11 @@ func TestSSHConsoleManagerConcurrent(t *testing.T) {
 	end := time.Now().Add(concurrentDuration)
 	var wg sync.WaitGroup
 
-	// attachWorker: Attach → drain a few messages → Detach in a tight loop.
+	// attachWorker repeatedly attaches, drains output, and detaches.
 	// Stresses clientsMu against broadcast from the Run goroutine.
 	for i := 0; i < concurrentWorkers; i++ {
-		wg.Add(1)
-		go func(workerID int) {
-			defer wg.Done()
+		workerID := i
+		wg.Go(func() {
 			rng := rand.New(rand.NewSource(int64(workerID)))
 			clientID := fmt.Sprintf("attach-worker-%d", workerID)
 			for time.Now().Before(end) {
@@ -137,69 +125,55 @@ func TestSSHConsoleManagerConcurrent(t *testing.T) {
 				}
 				manager.Detach(id, clientID)
 			}
-		}(i)
+		})
 	}
 
-	// writeWorker: Write to random nodes.
+	// writeWorker writes to random nodes.
 	// Stresses connMu against connect/disconnect cycling.
 	for i := 0; i < concurrentWorkers; i++ {
-		wg.Add(1)
-		go func(workerID int) {
-			defer wg.Done()
+		workerID := i
+		wg.Go(func() {
 			rng := rand.New(rand.NewSource(int64(workerID + 1000)))
 			payload := fmt.Appendf(nil, "worker-%d-ping\r\n", workerID)
 			for time.Now().Before(end) {
 				id := allIDs[rng.Intn(len(allIDs))]
 				if _, err := manager.Write(id, payload); err != nil {
-					// Node removed — not a bug.
+					// Node removal is expected.
 					time.Sleep(time.Millisecond)
 				}
 			}
-		}(i)
+		})
 	}
 
-	// credsWorker: UpdateCredentials in a tight loop.
-	// Stresses credsMu and the connMu path inside UpdateCreds.
-	//
-	// The passwords must actually differ between calls. If they are identical,
-	// credsChanged() is always false, UpdateCreds() is never reached, and the
-	// worker silently tests nothing — which is how a data race between
-	// UpdateCredentials' read of node.creds and UpdateCreds' write went
-	// unnoticed here. Both values authenticate, so nodes still connect.
+	// credsWorker alternates valid passwords to exercise UpdateCreds locking.
 	credSets := []map[string]compcredentials.CompCredentials{
 		makePasswordsWith(allIDs, testSSHPass),
 		makePasswordsWith(allIDs, testSSHPassAlt),
 	}
 	for i := 0; i < concurrentWorkers/2; i++ {
-		wg.Add(1)
-		go func(workerID int) {
-			defer wg.Done()
+		wg.Go(func() {
 			for round := 0; time.Now().Before(end); round++ {
 				manager.UpdateCredentials(credSets[round%len(credSets)])
 				time.Sleep(5 * time.Millisecond)
 			}
-		}(i)
+		})
 	}
 
-	// rotateWorker: Signal log rotation.
+	// rotateWorker repeatedly reopens logs.
 	// Stresses the reopenLogCh non-blocking send against broadcast.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for time.Now().Before(end) {
 			manager.ReopenLogs()
 			time.Sleep(10 * time.Millisecond)
 		}
-	}()
+	})
 
-	// updateWorker: Shuffle the node set — remove a few nodes and restore them.
+	// updateWorker removes and restores nodes.
 	// Stresses consolesMu against Attach/Detach/Write happening concurrently.
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		rng := rand.New(rand.NewSource(42))
 		for time.Now().Before(end) {
-			// Drop 1–3 nodes.
+			// Drop one to three nodes.
 			drop := rng.Intn(3) + 1
 			skipIdx := make(map[int]bool, drop)
 			for len(skipIdx) < drop {
@@ -225,7 +199,7 @@ func TestSSHConsoleManagerConcurrent(t *testing.T) {
 			manager.UpdateCredentials(passwords)
 			time.Sleep(20 * time.Millisecond)
 		}
-	}()
+	})
 
 	wg.Wait()
 

--- a/internal/ssh/console.go
+++ b/internal/ssh/console.go
@@ -6,6 +6,7 @@ package ssh
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -21,77 +22,78 @@ import (
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
 )
 
+// errNoCredentials means no credential entry has reached this node.
+// Run waits instead of dialing when credentials are unavailable.
+var errNoCredentials = errors.New("no credentials available for node")
+
 // consoleClient is one attached interactive client.
 type consoleClient struct {
 	ch chan []byte
-	// dropped counts bytes discarded because ch was full since the last drop
-	// notice this client was given. A console that silently skips output is
-	// worse than one that admits to a gap — an operator reading back a boot log
-	// has no other way to tell that something was cut.
+	// dropped counts bytes discarded since the last notice.
 	dropped int
 }
 
-// SSHConsole manages a single persistent SSH console connection.
-// Its Run goroutine is the sole writer for the log file and client channels —
-// no lock is needed for those writes.
+// SSHConsole manages one SSH node and persists across connections.
+// Run owns log and client channel writes and reconnects until cancelled.
 type SSHConsole struct {
 	nodeID  string
 	info    *nodes.NodeConsoleInfo
 	keyPath string
 	cfg     SSHConfig
 
+	// credsMu protects creds. Nil means no credential entry has arrived.
+	// An empty password may still select key authentication.
 	credsMu sync.RWMutex
-	creds   compcredentials.CompCredentials
+	creds   *compcredentials.CompCredentials
+	// credsCh wakes Run when credentials arrive.
+	credsCh chan struct{}
 
-	// clientsMu protects the clients map and the consoleClient values in it.
-	// broadcast takes it for writing because it updates each client's drop
-	// accounting; Attach and Detach are rare enough that the lost read
-	// concurrency does not matter.
-	// Lock ordering: consolesMu (manager) → clientsMu → connMu
-	clientsMu sync.RWMutex
-	clients   map[string]*consoleClient // channel closed and entry deleted on Detach or Run exit
+	// clientsMu protects clients and their drop counts.
+	// Locks are acquired in the order consolesMu, clientsMu, then connMu.
+	clientsMu sync.Mutex
+	clients   map[string]*consoleClient // closed on detach or shutdown
 
 	// connMu protects sshClient and stdin.
 	connMu    sync.Mutex
 	sshClient *gossh.Client
 	stdin     io.WriteCloser
 
-	// stdinMu serializes Write calls. golang.org/x/crypto/ssh reuses a per-channel
-	// packet buffer (packetPool) across WriteExtended calls, so concurrent writes
-	// to the same stdin pipe race. Multiple interactive clients may call Write
-	// simultaneously; this mutex ensures they are serialized.
-	stdinMu sync.Mutex
+	// writeMu serializes writes because SSH reuses a channel packet buffer.
+	// Multiple interactive clients may write concurrently.
+	writeMu sync.Mutex
 
-	// logFile is opened at the start of Run and written only from the Run goroutine.
+	// logFile is written only by Run.
 	logFile      *os.File
-	logPath      string        // logsPath + "/console." + nodeID
-	reopenLogCh  chan struct{} // buffered depth-1; signals broadcast to reopen after rotation
+	logPath      string
+	reopenLogCh  chan struct{} // buffered rotation signal
 	logFormatter consoleLogFormatter
 
-	// cancel is called by the manager to stop the Run goroutine.
-	// ctx is NOT stored in the struct to avoid the go vet context-in-struct antipattern.
+	// cancel stops Run without storing its context.
 	cancel context.CancelFunc
 }
 
-// newSSHConsole constructs an SSHConsole. The caller (manager) must set
-// node.cancel and call go node.Run(nodeCtx) after construction.
-func newSSHConsole(nodeID string, info *nodes.NodeConsoleInfo, creds compcredentials.CompCredentials, keyPath, logPath string, cfg SSHConfig) *SSHConsole {
+// newSSHConsole constructs an SSHConsole.
+// Nil credentials delay connection.
+func newSSHConsole(nodeID string, info *nodes.NodeConsoleInfo, creds *compcredentials.CompCredentials, keyPath, logPath string, cfg SSHConfig, cancel context.CancelFunc) *SSHConsole {
 	return &SSHConsole{
 		nodeID:       nodeID,
 		info:         info,
 		keyPath:      keyPath,
 		cfg:          cfg,
-		creds:        creds,
+		creds:        cloneCreds(creds),
 		clients:      make(map[string]*consoleClient),
 		logPath:      logPath,
 		reopenLogCh:  make(chan struct{}, 1),
 		logFormatter: newConsoleLogFormatter(),
+		credsCh:      make(chan struct{}, 1),
+		cancel:       cancel,
 	}
 }
 
 // streamStdout reads from the SSH session stdout and broadcasts to all clients
 // until the connection drops.
 func (c *SSHConsole) streamStdout(stdout io.Reader) {
+	// Match the default buffer size used by io.Copy.
 	buf := make([]byte, 32*1024)
 	for {
 		nr, err := stdout.Read(buf)
@@ -104,9 +106,8 @@ func (c *SSHConsole) streamStdout(stdout io.Reader) {
 	}
 }
 
-// connectAndStream attempts one connection, streams output until disconnect,
-// then cleans up. Returns true if the connection was established (used by Run
-// to reset the backoff on successful connects).
+// connectAndStream streams one connection and then cleans it up.
+// It reports whether the connection was established.
 func (c *SSHConsole) connectAndStream(ctx context.Context) bool {
 	stdout, err := c.connect(ctx)
 	if err != nil {
@@ -136,9 +137,8 @@ func (c *SSHConsole) connectAndStream(ctx context.Context) bool {
 
 	c.streamStdout(stdout)
 
-	// Clean up the connection. Nil stdin under connMu so Write sees nil and
-	// reports ErrNotConnected, then close it under stdinMu so an in-flight Write
-	// cannot race with Close on the underlying SSH channel buffer.
+	// Clear stdin before closing it so Write reports ErrNotConnected.
+	// writeMu prevents Close from racing with an active Write.
 	c.connMu.Lock()
 	if c.sshClient != nil {
 		_ = c.sshClient.Close()
@@ -148,9 +148,9 @@ func (c *SSHConsole) connectAndStream(ctx context.Context) bool {
 	c.stdin = nil
 	c.connMu.Unlock()
 	if stdin != nil {
-		c.stdinMu.Lock()
+		c.writeMu.Lock()
 		_ = stdin.Close()
-		c.stdinMu.Unlock()
+		c.writeMu.Unlock()
 	}
 
 	c.broadcast([]byte(fmt.Sprintf("\n[Console %s disconnected at %s]\n",
@@ -162,9 +162,8 @@ func (c *SSHConsole) connectAndStream(ctx context.Context) bool {
 // backoff is considered recovered and reset to ReconnectMinInterval.
 const stableConnection = 30 * time.Second
 
-// jitter returns d scaled by a random factor in [0.5, 1.0). Without it, a
-// network blip reconnects every node at the same instant — at the scale this
-// manager targets that is a thundering herd against the BMC network.
+// jitter spreads retries across the latter half of d.
+// This avoids simultaneous reconnects after a network failure.
 func jitter(d time.Duration) time.Duration {
 	if d <= 0 {
 		return 0
@@ -172,21 +171,14 @@ func jitter(d time.Duration) time.Duration {
 	return d/2 + time.Duration(rand.Int64N(int64(d/2)+1))
 }
 
-// Run is the main loop for the node. It connects, reads output, fans it out,
-// and reconnects on disconnect.
-//
-// It exits only when ctx is cancelled. The manager owns that ctx and cancels it
-// when the node leaves inventory, which makes the manager the single authority
-// on node lifetime. Run must not decide to stop on its own: the manager would
-// keep the node in its map with no goroutine behind it, so Attach would hand
-// back a channel that never delivers and no later update would revive it (the
-// node still "exists" and its parameters are unchanged).
+// Run connects, broadcasts output, and reconnects until cancelled.
+// The manager controls its lifetime and must not retain a stopped console.
 func (c *SSHConsole) Run(ctx context.Context) {
 	var err error
 	c.logFile, err = os.OpenFile(c.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
 		slog.Error("Failed to open SSH console log file", "nodeID", c.nodeID, "path", c.logPath, "error", err)
-		// Continue with nil logFile; broadcast skips write when nil.
+		// Continue without logging.
 	}
 	defer func() {
 		if c.logFile != nil {
@@ -202,17 +194,7 @@ func (c *SSHConsole) Run(ctx context.Context) {
 		c.clientsMu.Unlock()
 	}()
 
-	// Backstop against a config that never went through SSHConfig.Validate —
-	// a directly-constructed zero value would otherwise spin this loop with no
-	// wait between reconnects. Not a substitute for validation; just a floor so
-	// a programming error can't hammer the BMC network.
-	minBackoff := c.cfg.ReconnectMinInterval
-	if minBackoff < minReconnectInterval {
-		slog.Warn("SSH reconnect interval below minimum, clamping",
-			"nodeID", c.nodeID, "configured", minBackoff, "using", minReconnectInterval)
-		minBackoff = minReconnectInterval
-	}
-	backoff := minBackoff
+	backoff := c.cfg.ReconnectMinInterval
 
 	for {
 		select {
@@ -221,15 +203,26 @@ func (c *SSHConsole) Run(ctx context.Context) {
 		default:
 		}
 
+		// Wait for a credential entry before dialing.
+		// An empty password may select key authentication after it arrives.
+		if c.currentCreds() == nil {
+			slog.Info("SSH console node waiting for credentials", "nodeID", c.nodeID)
+			c.broadcast([]byte(fmt.Sprintf("\n[Console %s waiting for credentials]\n", c.nodeID)))
+			select {
+			case <-ctx.Done():
+				return
+			case <-c.credsCh:
+			}
+			continue
+		}
+
 		start := time.Now()
 		connected := c.connectAndStream(ctx)
 
-		// Only reset the backoff for a connection that actually held up. A host
-		// that accepts, authenticates, then immediately drops (bad entry command,
-		// session limit) would otherwise reset every cycle and be hammered at
-		// ReconnectMinInterval indefinitely.
+		// Reset backoff only after a stable connection.
+		// Immediate disconnects continue backing off.
 		if connected && time.Since(start) >= stableConnection {
-			backoff = minBackoff
+			backoff = c.cfg.ReconnectMinInterval
 		}
 
 		select {
@@ -245,19 +238,31 @@ func (c *SSHConsole) Run(ctx context.Context) {
 	}
 }
 
-// currentCreds returns a snapshot of the node's credentials under credsMu.
-// All reads of c.creds — including from the manager — must go through this.
-func (c *SSHConsole) currentCreds() compcredentials.CompCredentials {
+// currentCreds returns a copy of the credentials under credsMu.
+// Nil means no credential entry has arrived.
+func (c *SSHConsole) currentCreds() *compcredentials.CompCredentials {
 	c.credsMu.RLock()
 	defer c.credsMu.RUnlock()
-	return c.creds
+	return cloneCreds(c.creds)
+}
+
+// cloneCreds copies a nil-able credential so the original cannot be aliased.
+func cloneCreds(creds *compcredentials.CompCredentials) *compcredentials.CompCredentials {
+	if creds == nil {
+		return nil
+	}
+	c := *creds
+	return &c
 }
 
 // dialClient reads credentials, dials TCP, and completes the SSH handshake.
 func (c *SSHConsole) dialClient(ctx context.Context) (*gossh.Client, error) {
 	creds := c.currentCreds()
+	if creds == nil {
+		return nil, errNoCredentials
+	}
 
-	auth, err := c.buildAuth(creds)
+	auth, err := c.buildAuth(*creds)
 	if err != nil {
 		return nil, fmt.Errorf("build SSH auth: %w", err)
 	}
@@ -277,17 +282,15 @@ func (c *SSHConsole) dialClient(ctx context.Context) (*gossh.Client, error) {
 		return nil, fmt.Errorf("dial %s: %w", addr, err)
 	}
 
-	// gossh.NewClientConn neither takes a context nor honours ClientConfig.Timeout
-	// (that field is only consulted by gossh.Dial for the TCP dial), so a host that
-	// completes the TCP handshake but stalls the SSH one would block here forever.
-	// Guard it with both an absolute deadline and a ctx watchdog that closes the
-	// conn, so shutdown is not held up either.
+	// NewClientConn has no context and ignores ClientConfig.Timeout.
+	// Bound the handshake with a deadline and close it on cancellation.
 	if err := netConn.SetDeadline(time.Now().Add(c.cfg.ConnectTimeout)); err != nil {
 		_ = netConn.Close()
 		return nil, fmt.Errorf("set handshake deadline for %s: %w", addr, err)
 	}
 	handshakeDone := make(chan struct{})
 	defer close(handshakeDone)
+	// Cancel the handshake if the context is cancelled
 	go func() {
 		select {
 		case <-ctx.Done():
@@ -299,15 +302,14 @@ func (c *SSHConsole) dialClient(ctx context.Context) (*gossh.Client, error) {
 	sshConn, chans, reqs, err := gossh.NewClientConn(netConn, addr, &gossh.ClientConfig{
 		User:            creds.Username,
 		Auth:            auth,
-		HostKeyCallback: gossh.InsecureIgnoreHostKey(), //nolint:gosec // BMC management network; matches existing StrictHostKeyChecking=no
+		HostKeyCallback: gossh.InsecureIgnoreHostKey(), //nolint:gosec // Matches existing BMC host key behavior
 	})
 	if err != nil {
 		_ = netConn.Close()
 		return nil, fmt.Errorf("SSH handshake with %s: %w", addr, err)
 	}
 
-	// Clear the handshake deadline — the session is long-lived and must not
-	// inherit it. Liveness from here on is TCP keepalives.
+	// Clear the handshake deadline before starting the long-lived session.
 	if err := netConn.SetDeadline(time.Time{}); err != nil {
 		_ = sshConn.Close()
 		return nil, fmt.Errorf("clear handshake deadline for %s: %w", addr, err)
@@ -315,6 +317,12 @@ func (c *SSHConsole) dialClient(ctx context.Context) (*gossh.Client, error) {
 
 	return gossh.NewClient(sshConn, chans, reqs), nil
 }
+
+const (
+	terminalRows     = 24
+	terminalColumns  = 80
+	terminalBaudRate = 115200
+)
 
 // startSession opens a PTY session on client, wires up stdout/stdin pipes, and
 // starts the shell or entry command. Returns stdout and stdin on success.
@@ -324,10 +332,10 @@ func (c *SSHConsole) startSession(client *gossh.Client) (stdout io.Reader, stdin
 		return nil, nil, fmt.Errorf("new SSH session: %w", err)
 	}
 
-	if err := session.RequestPty(c.cfg.TerminalType, 24, 80, gossh.TerminalModes{
+	if err := session.RequestPty(c.cfg.TerminalType, terminalRows, terminalColumns, gossh.TerminalModes{
 		gossh.ECHO:          1,
-		gossh.TTY_OP_ISPEED: 115200, // matches conman seropts="115200,8n1"
-		gossh.TTY_OP_OSPEED: 115200,
+		gossh.TTY_OP_ISPEED: terminalBaudRate,
+		gossh.TTY_OP_OSPEED: terminalBaudRate,
 	}); err != nil {
 		_ = session.Close()
 		return nil, nil, fmt.Errorf("request PTY: %w", err)
@@ -365,16 +373,14 @@ func (c *SSHConsole) startSession(client *gossh.Client) (stdout io.Reader, stdin
 	return stdout, stdin, nil
 }
 
-// connect dials the remote host, opens a PTY session, and stores connection
-// state. Returns the stdout reader on success; caller must drain it until
-// error/EOF.
+// connect opens a PTY session and stores its connection state.
+// The caller drains stdout until EOF or error.
 func (c *SSHConsole) connect(ctx context.Context) (io.Reader, error) {
 	client, err := c.dialClient(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// Track whether connect succeeds so the defer can clean up on failure.
 	success := false
 	defer func() {
 		if !success {
@@ -406,17 +412,15 @@ func (c *SSHConsole) connect(ctx context.Context) (io.Reader, error) {
 	return stdout, nil
 }
 
-// buildAuth selects the SSH auth method based on credentials and keyPath.
-// Priority matches the original ssh-pwd-console / ssh-key-console scripts:
-//   - Password set → password auth (even when a key file is also present)
-//   - No password   → key auth: cert+key if cert exists, key-only otherwise
+// buildAuth selects authentication for a credential entry.
+// Passwords take priority. Empty passwords use the key and optional certificate.
 func (c *SSHConsole) buildAuth(creds compcredentials.CompCredentials) ([]gossh.AuthMethod, error) {
-	// Password takes priority — matches ssh-pwd-console behaviour.
+	// Password authentication takes priority.
 	if creds.Password != "" {
 		return []gossh.AuthMethod{gossh.Password(creds.Password)}, nil
 	}
 
-	// No password: attempt key-based auth — matches ssh-key-console behaviour.
+	// Use key authentication when the password is empty.
 	if c.keyPath == "" {
 		return nil, fmt.Errorf("no SSH auth available for %s: no password and no key path configured", c.nodeID)
 	}
@@ -430,7 +434,6 @@ func (c *SSHConsole) buildAuth(creds compcredentials.CompCredentials) ([]gossh.A
 		return nil, fmt.Errorf("parse SSH private key: %w", err)
 	}
 
-	// Check for a certificate alongside the key.
 	certPath := c.keyPath + "-cert.pub"
 	certData, err := os.ReadFile(certPath)
 	if err == nil {
@@ -449,14 +452,13 @@ func (c *SSHConsole) buildAuth(creds compcredentials.CompCredentials) ([]gossh.A
 		return []gossh.AuthMethod{gossh.PublicKeys(certSigner)}, nil
 	}
 
-	// Key only (no cert).
 	return []gossh.AuthMethod{gossh.PublicKeys(signer)}, nil
 }
 
-// broadcast sends data to the log file and all attached client channels.
-// Called only from the Run goroutine — no lock needed for logFile writes.
+// broadcast writes data to the log and attached clients.
+// Run is its only caller.
 func (c *SSHConsole) broadcast(data []byte) {
-	// Handle log rotation signal (non-blocking, depth-1 channel debounces).
+	// Apply one pending log rotation signal.
 	select {
 	case <-c.reopenLogCh:
 		if c.logFile != nil {
@@ -486,15 +488,9 @@ func (c *SSHConsole) broadcast(data []byte) {
 	}
 }
 
-// sendToClient delivers data to one client, accounting for anything discarded
-// because its channel was full. Must be called with clientsMu held for writing.
-//
-// A drop notice cannot be delivered at the moment of the drop — the channel is
-// full, which is the whole problem. It is held until the client has drained
-// enough to accept it, and every byte lost in the meantime is folded into the
-// same notice, so a client stalled for megabytes gets one accurate line rather
-// than a flood. The notice is emitted before the data that follows it, which
-// puts the gap marker in the right place in the client's stream.
+// sendToClient delivers data while tracking dropped bytes.
+// Drop notices wait for capacity and precede new data.
+// Call with clientsMu held for writing.
 func (c *SSHConsole) sendToClient(id string, client *consoleClient, data []byte) {
 	if client.dropped > 0 {
 		select {
@@ -503,7 +499,7 @@ func (c *SSHConsole) sendToClient(id string, client *consoleClient, data []byte)
 				"nodeID", c.nodeID, "clientID", id, "bytesDropped", client.dropped)
 			client.dropped = 0
 		default:
-			// Still backed up. Keep counting; do not try to send the data.
+			// Keep counting while the client is backed up.
 			client.dropped += len(data)
 			return
 		}
@@ -513,9 +509,7 @@ func (c *SSHConsole) sendToClient(id string, client *consoleClient, data []byte)
 	case client.ch <- append([]byte{}, data...):
 	default:
 		if client.dropped == 0 {
-			// Log the transition only. Logging every dropped chunk would put
-			// one line per 32KB read into the service log for as long as the
-			// client stays behind.
+			// Log only when dropping begins.
 			slog.Warn("SSH console client not keeping up, dropping output",
 				"nodeID", c.nodeID, "clientID", id)
 		}
@@ -530,20 +524,11 @@ func dropNotice(nodeID string, bytesDropped int) []byte {
 		nodeID, bytesDropped)
 }
 
-// clientBufferDepth is how many output chunks a client may fall behind before
-// the node starts discarding its output. It matches the conman backend so both
-// consoles behave the same under a slow client.
-//
-// The unit is chunks, not bytes: one chunk is whatever a single read of the SSH
-// session returned, up to the 32KB streamStdout buffer. Depth buys a client
-// time to recover from a stall, but only up to a point — an interactive console
-// that is megabytes behind is not much use, and past there an acknowledged gap
-// beats a long lag. Raise this only with evidence from the "not keeping up"
-// warning in the service log.
+// clientBufferDepth limits queued output for each client.
+// It matches ConMan buffering. Each item is up to 32 KB.
 const clientBufferDepth = 256
 
-// Attach registers a client receive channel. Returns a buffered channel that
-// receives console output. The manager ensures the node exists before calling.
+// Attach registers a buffered client channel.
 func (c *SSHConsole) Attach(clientID string) chan []byte {
 	ch := make(chan []byte, clientBufferDepth)
 	c.clientsMu.Lock()
@@ -562,13 +547,11 @@ func (c *SSHConsole) Detach(clientID string) {
 	}
 }
 
-// Write sends data to the SSH session's stdin. It reports ErrNotConnected
-// rather than claiming a successful write when the node is between
-// connections, so callers can decide what to do with the discarded input; a
-// transient disconnect is not a reason to tear the caller down.
+// Write sends data to the SSH session.
+// ErrNotConnected means no input was written during a reconnect.
 func (c *SSHConsole) Write(p []byte) (int, error) {
-	c.stdinMu.Lock()
-	defer c.stdinMu.Unlock()
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
 
 	c.connMu.Lock()
 	stdin := c.stdin
@@ -584,8 +567,15 @@ func (c *SSHConsole) Write(p []byte) (int, error) {
 // credentials take effect.
 func (c *SSHConsole) UpdateCreds(creds compcredentials.CompCredentials) {
 	c.credsMu.Lock()
-	c.creds = creds
+	c.creds = &creds
 	c.credsMu.Unlock()
+
+	// Wake Run when the first credentials arrive.
+	// A buffered signal avoids missed wakeups.
+	select {
+	case c.credsCh <- struct{}{}:
+	default:
+	}
 
 	// Close the current connection to trigger reconnect with new creds.
 	c.connMu.Lock()
@@ -600,6 +590,6 @@ func (c *SSHConsole) UpdateCreds(creds compcredentials.CompCredentials) {
 func (c *SSHConsole) ReopenLog() {
 	select {
 	case c.reopenLogCh <- struct{}{}:
-	default: // already signalled; no-op
+	default: // already signalled
 	}
 }

--- a/internal/ssh/console_test.go
+++ b/internal/ssh/console_test.go
@@ -17,13 +17,7 @@ import (
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
 )
 
-// ---------------------------------------------------------------------------
-// 1. Reconnect on disconnect
-// ---------------------------------------------------------------------------
-
-// TestSSHConsoleReconnect verifies that when the server drops a connection
-// the node broadcasts a disconnect marker, then reconnects automatically and
-// broadcasts a connected marker.
+// TestSSHConsoleReconnect verifies automatic reconnection and status markers.
 func TestSSHConsoleReconnect(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
@@ -45,24 +39,15 @@ func TestSSHConsoleReconnect(t *testing.T) {
 	sess := <-sessionCh
 	waitForMarker(t, clientCh, fmt.Sprintf("[Console %s connected at", id), 15*time.Second)
 
-	// Drop the connection server-side.
 	sess.drop()
 
-	// Node should broadcast a disconnect marker.
 	waitForMarker(t, clientCh, fmt.Sprintf("[Console %s disconnected at", id), 15*time.Second)
 
-	// Server accepts the reconnect; node should broadcast another connected marker.
 	<-sessionCh
 	waitForMarker(t, clientCh, fmt.Sprintf("[Console %s connected at", id), 15*time.Second)
 }
 
-// ---------------------------------------------------------------------------
-// 2. Fan-out broadcast to multiple clients
-// ---------------------------------------------------------------------------
-
-// TestSSHConsoleFanOut verifies that output from the SSH session is
-// delivered to every attached client and that a slow client (full buffer)
-// only loses its own data — it does not block other clients.
+// TestSSHConsoleFanOut verifies output reaches all clients independently.
 func TestSSHConsoleFanOut(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
@@ -92,15 +77,13 @@ func TestSSHConsoleFanOut(t *testing.T) {
 		waitForMarker(t, ch, fmt.Sprintf("[Console %s connected at", id), 15*time.Second)
 	}
 
-	// Server sends a known payload; every client must receive it.
 	sess.send <- []byte("broadcast-test-payload\r\n")
 	for i, ch := range clients {
 		waitForMarker(t, ch, "broadcast-test-payload", 5*time.Second)
 		t.Logf("client %d received payload", i)
 	}
 
-	// Slow-client test: fill one client's buffer so it is full, then verify
-	// the fast client still receives new data unimpeded.
+	// A full client buffer must not block another client.
 	slowCh, err := manager.Attach(id, "slow-client")
 	if err != nil {
 		t.Fatal(err)
@@ -117,20 +100,14 @@ func TestSSHConsoleFanOut(t *testing.T) {
 	for i := 0; i < 64; i++ {
 		sess.send <- filler
 	}
-	time.Sleep(200 * time.Millisecond) // let broadcast goroutine saturate the slow client
+	time.Sleep(200 * time.Millisecond) // allow the slow client buffer to fill
 
 	sess.send <- []byte("after-slow-client-fill\r\n")
 	waitForMarker(t, fastCh, "after-slow-client-fill", 5*time.Second)
-	_ = slowCh // slow client may have dropped data — expected behaviour
+	_ = slowCh // slow client may have dropped data
 }
 
-// ---------------------------------------------------------------------------
-// 3. Data flow: output reaches clients, input reaches server
-// ---------------------------------------------------------------------------
-
-// TestSSHConsoleDataFlow verifies that bytes written by the server arrive
-// in the client channel (output path) and bytes written by the client arrive
-// at the server's stdin (input path).
+// TestSSHConsoleDataFlow verifies input and output forwarding.
 func TestSSHConsoleDataFlow(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
@@ -151,11 +128,9 @@ func TestSSHConsoleDataFlow(t *testing.T) {
 	sess := <-sessionCh
 	waitForMarker(t, clientCh, fmt.Sprintf("[Console %s connected at", id), 15*time.Second)
 
-	// Output path: server → client.
 	sess.send <- []byte("hello-from-server\r\n")
 	waitForMarker(t, clientCh, "hello-from-server", 5*time.Second)
 
-	// Input path: client → server.
 	if _, err := manager.Write(id, []byte("hello-from-client\r\n")); err != nil {
 		t.Fatalf("Write: %v", err)
 	}
@@ -177,12 +152,7 @@ func TestSSHConsoleDataFlow(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// 4. Node lifecycle via UpdateNodes
-// ---------------------------------------------------------------------------
-
-// TestSSHConsoleLifecycle verifies that removing a node via UpdateNodes
-// cancels its Run goroutine and that all associated goroutines exit cleanly.
+// TestSSHConsoleLifecycle verifies node removal stops its goroutines.
 func TestSSHConsoleLifecycle(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
@@ -196,17 +166,14 @@ func TestSSHConsoleLifecycle(t *testing.T) {
 
 	startNodes(t, manager, ctx, nodeMap, passwords)
 
-	// Wait for the node to connect.
 	<-sessionCh
 	t.Logf("goroutines with node: %d (added %d)", runtime.NumGoroutine(), runtime.NumGoroutine()-goroutinesBefore)
 
-	// Remove the node. The manager is the sole authority on node lifetime, so
-	// cancelling through UpdateNodes must be enough to stop Run.
+	// Removing the node must stop Run.
 	if err := manager.UpdateNodes(ctx, map[string]*nodes.NodeConsoleInfo{}); err != nil {
 		t.Fatal(err)
 	}
 
-	// Attach should now fail.
 	if _, err := manager.Attach(id, "post-remove"); err == nil {
 		t.Error("Attach succeeded after node removal")
 	}
@@ -226,16 +193,7 @@ func TestSSHConsoleLifecycle(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// 6. Slow client accounting
-// ---------------------------------------------------------------------------
-
-// TestSlowClientGetsDropNotice covers the case where a client cannot keep up
-// with console output. The node has to discard the overflow — it will not stall
-// every other client and the log file to wait for one slow websocket — but
-// discarding it silently hands the operator a console stream with an
-// unmarked hole in it. The dropped bytes must be accounted for in the client's
-// own stream once it drains enough to receive the notice.
+// TestSlowClientGetsDropNotice verifies dropped output is reported in place.
 func TestSlowClientGetsDropNotice(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
@@ -256,17 +214,8 @@ func TestSlowClientGetsDropNotice(t *testing.T) {
 	sess := <-sessionCh
 	waitForMarker(t, clientCh, fmt.Sprintf("[Console %s connected at", id), 15*time.Second)
 
-	// Flood the node while reading nothing. The server's writes are
-	// flow-controlled by the SSH window, which only advances as the node reads,
-	// so once every send has been accepted the node has consumed the lot — and
-	// with the client reading none of it, everything past the channel's depth
-	// must have been dropped.
-	//
-	// The burst has to beat that depth measured in broadcasts, not bytes.
-	// streamStdout reads up to 32KB at a time, so the worst case for this test
-	// is the sends coalescing into 32KB chunks: 24MB still yields ~750
-	// broadcasts against a channel that holds clientBufferDepth (256). Keep the
-	// margin if that constant grows.
+	// Send enough data to overflow the client buffer even with 32 KB reads.
+	// The SSH window confirms accepted data was consumed by the console.
 	const (
 		bursts    = 1500
 		chunkSize = 16 * 1024
@@ -283,10 +232,7 @@ func TestSlowClientGetsDropNotice(t *testing.T) {
 		}
 	}
 
-	// Drain what the client did manage to buffer, keeping everything it saw.
-	// The notice may land here — as soon as the channel has room, the next
-	// broadcast carries it — or on the resume write below, so the assertions
-	// have to look at the whole stream rather than at one read.
+	// The notice may arrive while draining or after output resumes.
 	var seen strings.Builder
 	drained := 0
 	draining := true
@@ -325,8 +271,7 @@ func TestSlowClientGetsDropNotice(t *testing.T) {
 	if !strings.Contains(seen.String()[at:], "bytes of output dropped") {
 		t.Errorf("drop notice is not the expected marker: %q", seen.String()[at:min(at+120, seen.Len())])
 	}
-	// The notice has to sit at the gap. Behind the resumed output it would tell
-	// the operator the wrong thing about where the console skipped.
+	// The notice must precede resumed output.
 	if at > strings.Index(seen.String(), "back-in-sync") {
 		t.Error("drop notice arrived after the resumed output; it marks the wrong point in the stream")
 	}

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -17,29 +17,27 @@ import (
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
 )
 
-// ErrNotConnected means a managed console is temporarily disconnected. Write discards input and
+// ErrNotConnected means a managed node is temporarily disconnected. Write discards input and
 // returns this error until reconnect.
-var ErrNotConnected = errors.New("ssh console console not connected")
+var ErrNotConnected = errors.New("ssh console node not connected")
 
-// SSHConsoleManager manages the set of active SSHConsoleNodes.
+// SSHConsoleManager manages one console for each SSH node.
 type SSHConsoleManager struct {
 	cfg      SSHConfig
 	keyPath  string
 	logsPath string // e.g. /var/log/conman/conman
 
-	// consolesMu protects the nodes map.
-	// Lock ordering: consolesMu → clientsMu, consolesMu → connMu
+	// consolesMu protects consoles.
 	consolesMu sync.RWMutex
 	consoles   map[string]*SSHConsole
-	// cancels maps nodeID to the cancel func for that console's Run goroutine.
-	cancels map[string]context.CancelFunc
+	cancels    map[string]context.CancelFunc
 
 	// running tracks Run goroutines through final cleanup.
 	running sync.WaitGroup
 }
 
 // NewSSHConsoleManager creates a manager from validated configuration. keyPath may be empty when
-// all nodes use password authentication. logsPath stores per-console console logs.
+// all nodes use password authentication. logsPath stores per-node console logs.
 func NewSSHConsoleManager(cfg SSHConfig, keyPath, logsPath string) *SSHConsoleManager {
 	return &SSHConsoleManager{
 		cfg:      cfg,
@@ -50,12 +48,12 @@ func NewSSHConsoleManager(cfg SSHConfig, keyPath, logsPath string) *SSHConsoleMa
 	}
 }
 
-// logPath returns the log file path for a console.
+// logPath returns the log file path for a node.
 func (m *SSHConsoleManager) logPath(nodeID string) string {
 	return filepath.Join(m.logsPath, "console."+nodeID)
 }
 
-// nodeChanged reports whether a console's connection parameters have changed.
+// nodeChanged reports whether a node's connection parameters have changed.
 func nodeChanged(existing *nodes.NodeConsoleInfo, updated *nodes.NodeConsoleInfo) bool {
 	return existing.ConnectionHost != updated.ConnectionHost ||
 		existing.ConnectionPort != updated.ConnectionPort ||
@@ -67,10 +65,10 @@ func credsChanged(a, b compcredentials.CompCredentials) bool {
 	return a.Username != b.Username || a.Password != b.Password
 }
 
-// UpdateNodes syncs managed consoles with the provided SSH console set. It starts new nodes, stops
-// removed nodes, and restarts consoles when connection settings change. Existing nodes retain
-// their credentials. ctx controls console lifetime. New nodes use key authentication until
-// UpdateCredentials supplies a password.
+// UpdateNodes syncs managed consoles with the provided SSH node set. It starts new SSH nodes and
+// stops removed nodes. Connection changes restart a console with its existing
+// credentials, while new nodes wait for UpdateCredentials before connecting. ctx controls
+// console lifetime.
 func (m *SSHConsoleManager) UpdateNodes(
 	ctx context.Context,
 	sshNodes map[string]*nodes.NodeConsoleInfo,
@@ -78,10 +76,10 @@ func (m *SSHConsoleManager) UpdateNodes(
 	m.consolesMu.Lock()
 	defer m.consolesMu.Unlock()
 
-	// Stop nodes that are no longer in the updated set.
+	// Stop the consoles of nodes that are no longer in the updated set.
 	for nodeID, cancel := range m.cancels {
 		if _, stillActive := sshNodes[nodeID]; !stillActive {
-			slog.Info("Stopping SSH console console", "nodeID", nodeID)
+			slog.Info("Stopping SSH console", "nodeID", nodeID)
 			cancel()
 			delete(m.consoles, nodeID)
 			delete(m.cancels, nodeID)
@@ -91,14 +89,15 @@ func (m *SSHConsoleManager) UpdateNodes(
 	for nodeID, info := range sshNodes {
 		existing, exists := m.consoles[nodeID]
 		if !exists {
-			m.startConsole(ctx, nodeID, info, compcredentials.CompCredentials{})
+			// nil credentials: the console parks until UpdateCredentials reaches it.
+			m.startConsole(ctx, nodeID, info, nil)
 			continue
 		}
 
 		if nodeChanged(existing.info, info) {
-			// Connection parameters changed — restart with the credentials the
-			// console is already using.
-			slog.Info("SSH console console parameters changed, restarting", "nodeID", nodeID)
+			// Connection parameters changed — replace the console, carrying the
+			// credentials the old one was using.
+			slog.Info("SSH console node parameters changed, restarting", "nodeID", nodeID)
 			creds := existing.currentCreds()
 			m.cancels[nodeID]()
 			m.startConsole(ctx, nodeID, info, creds)
@@ -108,18 +107,18 @@ func (m *SSHConsoleManager) UpdateNodes(
 	return nil
 }
 
-// startConsole creates and starts a new SSHConsole. Must be called with consolesMu held.
-func (m *SSHConsoleManager) startConsole(ctx context.Context, nodeID string, info *nodes.NodeConsoleInfo, creds compcredentials.CompCredentials) {
-	nodeCtx, nodeCancel := context.WithCancel(ctx)
-	console := newSSHConsole(nodeID, info, creds, m.keyPath, m.logPath(nodeID), m.cfg)
-	console.cancel = nodeCancel
+// startConsole creates and starts one console. Call with consolesMu held. Nil credentials delay
+// connection.
+func (m *SSHConsoleManager) startConsole(ctx context.Context, nodeID string, info *nodes.NodeConsoleInfo, creds *compcredentials.CompCredentials) {
+	consoleCtx, consoleCancel := context.WithCancel(ctx)
+	console := newSSHConsole(nodeID, info, creds, m.keyPath, m.logPath(nodeID), m.cfg, consoleCancel)
 	m.consoles[nodeID] = console
-	m.cancels[nodeID] = nodeCancel
-	slog.Info("Starting SSH console console", "nodeID", nodeID, "host", info.ConnectionHost)
+	m.cancels[nodeID] = consoleCancel
+	slog.Info("Starting SSH console", "nodeID", nodeID, "host", info.ConnectionHost)
 	m.running.Add(1)
 	go func() {
 		defer m.running.Done()
-		console.Run(nodeCtx)
+		console.Run(consoleCtx)
 	}()
 }
 
@@ -129,8 +128,19 @@ func (m *SSHConsoleManager) Wait() {
 	m.running.Wait()
 }
 
-// UpdateCredentials updates credentials for managed nodes present in passwords.
-// Nodes absent from passwords retain their current credentials.
+// UpdateCredentials delivers Vault entries to managed nodes, reconnecting any
+// node whose entry differs from the one it is using. It is the only way
+// credentials enter the manager; UpdateNodes never touches them.
+//
+// Only node IDs present in passwords are considered. An absent node is left
+// alone rather than cleared: a credential that has not arrived is not evidence
+// that a node has none, and a fetch can come back short for reasons that have
+// nothing to do with the node. A caller may therefore pass whatever it managed
+// to fetch without first deciding whether the result is complete.
+//
+// Moving a node from password to key auth is done by clearing the password on
+// its Vault entry, not by deleting the entry — the username is still needed
+// either way. That arrives here as a changed entry and is applied normally.
 func (m *SSHConsoleManager) UpdateCredentials(passwords map[string]compcredentials.CompCredentials) {
 	m.consolesMu.RLock()
 	type pending struct {
@@ -140,7 +150,8 @@ func (m *SSHConsoleManager) UpdateCredentials(passwords map[string]compcredentia
 	var updates []pending
 	for nodeID, console := range m.consoles {
 		if creds, ok := passwords[nodeID]; ok {
-			if credsChanged(console.currentCreds(), creds) {
+			// A node still waiting for its first entry always counts as changed.
+			if current := console.currentCreds(); current == nil || credsChanged(*current, creds) {
 				updates = append(updates, pending{console, creds})
 			}
 		}
@@ -152,7 +163,7 @@ func (m *SSHConsoleManager) UpdateCredentials(passwords map[string]compcredentia
 	}
 }
 
-// ReopenLogs signals all active nodes to reopen their log files after rotation.
+// ReopenLogs signals all active consoles to reopen their log files after rotation.
 func (m *SSHConsoleManager) ReopenLogs() {
 	m.consolesMu.RLock()
 	defer m.consolesMu.RUnlock()
@@ -161,13 +172,13 @@ func (m *SSHConsoleManager) ReopenLogs() {
 	}
 }
 
-// Attach connects a client and fails if the console is unmanaged.
+// Attach connects a client and fails if the node is unmanaged.
 func (m *SSHConsoleManager) Attach(nodeID, clientID string) (chan []byte, error) {
 	m.consolesMu.RLock()
 	console, ok := m.consoles[nodeID]
 	m.consolesMu.RUnlock()
 	if !ok {
-		return nil, fmt.Errorf("SSH console console %q not found", nodeID)
+		return nil, fmt.Errorf("SSH console node %q not found", nodeID)
 	}
 	return console.Attach(clientID), nil
 }
@@ -182,13 +193,13 @@ func (m *SSHConsoleManager) Detach(nodeID, clientID string) {
 	}
 }
 
-// Write sends data to a console and distinguishes unmanaged nodes from temporary disconnections.
+// Write sends data to a node and distinguishes unmanaged nodes from temporary disconnections.
 func (m *SSHConsoleManager) Write(nodeID string, p []byte) (int, error) {
 	m.consolesMu.RLock()
 	console, ok := m.consoles[nodeID]
 	m.consolesMu.RUnlock()
 	if !ok {
-		return 0, fmt.Errorf("SSH console console %q not found", nodeID)
+		return 0, fmt.Errorf("SSH console node %q not found", nodeID)
 	}
 	return console.Write(p)
 }

--- a/internal/ssh/manager_test.go
+++ b/internal/ssh/manager_test.go
@@ -8,6 +8,8 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -79,12 +81,8 @@ func waitForBytes(t *testing.T, sess *sshSession, want string, timeout time.Dura
 	}
 }
 
-// TestUpdateNodesPreservesCredentials covers the case where the service's
-// credential fetch failed and it falls back to a credential-preserving
-// update. A
-// healthy node must keep running on the credentials it already has. Applying
-// the empty password would trigger UpdateCreds, drop the connection, and then
-// fall through to key auth, which is not what this node uses.
+// TestUpdateNodesPreservesCredentials verifies membership updates retain active credentials.
+// Clearing credentials would drop a healthy session and incorrectly select key authentication.
 func TestUpdateNodesPreservesCredentials(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
@@ -111,8 +109,6 @@ func TestUpdateNodesPreservesCredentials(t *testing.T) {
 	}
 	waitForBytes(t, sess, "before", 15*time.Second)
 
-	// Same node set, credentials incomplete — what the service does when the
-	// fetch fails.
 	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
 		t.Fatal(err)
 	}
@@ -121,7 +117,7 @@ func TestUpdateNodesPreservesCredentials(t *testing.T) {
 	// cleared, UpdateCreds would have torn this connection down.
 	select {
 	case <-sessionCh:
-		t.Fatal("node reconnected after a credential-preserving update; existing credentials were not preserved")
+		t.Fatal("node reconnected after a membership-only update; UpdateNodes touched its credentials")
 	case <-time.After(2 * time.Second):
 	}
 
@@ -131,10 +127,8 @@ func TestUpdateNodesPreservesCredentials(t *testing.T) {
 	waitForBytes(t, sess, "after", 15*time.Second)
 }
 
-// TestUpdateNodesAddsAndRemovesNodes verifies that a credential-preserving update
-// still adds and removes nodes. Before this, a failed credential fetch skipped
-// the SSH update entirely, so a node removed from inventory kept its console
-// running and a newly added node never started.
+// TestUpdateNodesAddsAndRemovesNodes verifies membership changes do not depend on credential
+// delivery. Inventory updates must proceed even when credentials are unavailable.
 func TestUpdateNodesAddsAndRemovesNodes(t *testing.T) {
 	srv := newSSHServer(t, func(ch gossh.Channel) { _ = ch.Close() })
 	id, nodeMap, _ := singleNode(t, srv.addr())
@@ -143,27 +137,30 @@ func TestUpdateNodesAddsAndRemovesNodes(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	// Add. The node must be registered so a later UpdateCredentials can reach it.
+	// Register the node before credentials arrive.
 	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := manager.Attach(id, "probe"); err != nil {
-		t.Fatalf("node was not registered by a credential-preserving update: %v", err)
+		t.Fatalf("node was not registered by UpdateNodes: %v", err)
 	}
 	manager.Detach(id, "probe")
 
-	// Remove.
 	if err := manager.UpdateNodes(ctx, map[string]*nodes.NodeConsoleInfo{}); err != nil {
 		t.Fatal(err)
 	}
 	if _, err := manager.Attach(id, "probe"); err == nil {
-		t.Fatal("node still registered after removal via a credential-less update")
+		t.Fatal("node still registered after UpdateNodes dropped it")
 	}
 }
 
-// TestUpdateCredentialsIgnoresAbsentNodes verifies that a credential update only
-// affects nodes present in the supplied map. An absent entry may reflect a
-// partial fetch and must not clear working credentials.
+// TestUpdateCredentialsIgnoresAbsentNodes pins the property that lets callers
+// pass a credential map they cannot vouch for. GetPasswordsWithRetries returns
+// whatever it managed to fetch with a nil error once it exhausts its retries,
+// so an absent nodeID says nothing about the node — only that this fetch did
+// not bring it back. UpdateCredentials must therefore leave absent nodes alone:
+// treating absence as a change would tear down a working console every time the
+// credential store had a bad minute.
 func TestUpdateCredentialsIgnoresAbsentNodes(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
@@ -184,16 +181,80 @@ func TestUpdateCredentialsIgnoresAbsentNodes(t *testing.T) {
 	sess := <-sessionCh
 	waitForMarker(t, clientCh, "[Console "+id+" connected at", 15*time.Second)
 
+	// An empty map — every node absent. Nothing may happen to this connection.
 	manager.UpdateCredentials(map[string]compcredentials.CompCredentials{})
 
 	select {
 	case <-sessionCh:
-		t.Fatal("node reconnected after an update that did not mention it")
+		t.Fatal("node reconnected after an update that did not mention it; absence was read as a credential change")
 	case <-time.After(2 * time.Second):
 	}
 
+	// Still the same live session, not a silently re-established one.
 	if _, err := manager.Write(id, []byte("still-here\n")); err != nil {
 		t.Fatalf("write after the empty credential update: %v", err)
 	}
 	waitForBytes(t, sess, "still-here", 15*time.Second)
+}
+
+// waitForLogMarker polls a node log until it contains marker. Logs retain markers emitted before
+// clients can attach, which avoids attachment timing races.
+func waitForLogMarker(t *testing.T, logsDir, nodeID, marker string, timeout time.Duration) {
+	t.Helper()
+	path := filepath.Join(logsDir, "console."+nodeID)
+	deadline := time.Now().Add(timeout)
+	var last []byte
+	for time.Now().Before(deadline) {
+		data, err := os.ReadFile(path)
+		if err == nil {
+			last = data
+			if strings.Contains(string(data), marker) {
+				return
+			}
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for %q in %s; log contains: %q", marker, path, string(last))
+}
+
+// TestNodeWithoutCredentialsWaitsInsteadOfDialling verifies provisioning nodes wait for a
+// credential entry. Every node requires a username, even for key authentication, so dialing
+// before the entry arrives would report a misleading authentication failure.
+func TestNodeWithoutCredentialsWaitsInsteadOfDialling(t *testing.T) {
+	sessionCh := make(chan *sshSession)
+	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
+	id, nodeMap, passwords := singleNode(t, srv.addr())
+
+	logsDir := t.TempDir()
+	manager := newManager(t, logsDir)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Register membership without credentials.
+	if err := manager.UpdateNodes(ctx, nodeMap); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForLogMarker(t, logsDir, id, "waiting for credentials", 10*time.Second)
+
+	// Wait beyond several reconnect intervals to detect an unintended dial.
+	time.Sleep(3 * time.Second)
+
+	if got := srv.accepts.Load(); got != 0 {
+		t.Errorf("node made %d connection attempt(s) with no credentials, want 0", got)
+	}
+	select {
+	case <-sessionCh:
+		t.Fatal("node established a session before it had any credentials")
+	default:
+	}
+
+	// Credential delivery must wake the node without waiting for a timer.
+	manager.UpdateCredentials(passwords)
+
+	select {
+	case <-sessionCh:
+	case <-time.After(15 * time.Second):
+		t.Fatal("node did not connect after its credentials arrived")
+	}
 }

--- a/internal/ssh/server_test.go
+++ b/internal/ssh/server_test.go
@@ -4,9 +4,6 @@
 
 package ssh_test
 
-// In-process SSH test server and shared test helpers used across scale,
-// concurrent, and node-behaviour tests.
-
 import (
 	"context"
 	"crypto/ed25519"
@@ -15,6 +12,7 @@ import (
 	"net"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -25,35 +23,26 @@ import (
 	"github.com/OpenCHAMI/remote-console/internal/ssh"
 )
 
-// ---------------------------------------------------------------------------
-// Test credentials (shared across all tests)
-// ---------------------------------------------------------------------------
-
 const (
 	testSSHUser = "testuser"
 	testSSHPass = "testpass"
-	// testSSHPassAlt is a second valid password. Tests that need credentials to
-	// actually change (so credsChanged() flips and UpdateCreds() is reached) can
-	// alternate between the two without breaking authentication.
+	// testSSHPassAlt allows credential changes without breaking authentication.
 	testSSHPassAlt = "testpass-alt"
 )
 
-// ---------------------------------------------------------------------------
-// sshServer — in-process SSH server
-// ---------------------------------------------------------------------------
-
-// sshServer is a minimal in-process SSH server. When a client establishes a
-// shell or exec session, onShell is called in its own goroutine with the
-// accepted channel. onShell is responsible for draining the channel and closing
-// it when done. All connections share a single listener on a random loopback port.
+// sshServer is a minimal in-process server on a random loopback port. It calls onShell in a new
+// goroutine for each shell or exec session. onShell drains and closes the accepted channel.
 type sshServer struct {
 	listener net.Listener
 	cfg      *gossh.ServerConfig
 	onShell  func(ch gossh.Channel)
+
+	// accepts counts TCP connections before authentication. It is the earliest observable
+	// connection attempt.
+	accepts atomic.Int64
 }
 
-// newSSHServer starts an in-process SSH server that accepts password auth with
-// testSSHUser/testSSHPass and calls onShell for every established shell session.
+// newSSHServer starts a password-authenticated test server.
 func newSSHServer(t *testing.T, onShell func(gossh.Channel)) *sshServer {
 	t.Helper()
 
@@ -95,6 +84,7 @@ func (s *sshServer) serve() {
 		if err != nil {
 			return
 		}
+		s.accepts.Add(1)
 		go s.handleConn(conn)
 	}
 }
@@ -138,10 +128,6 @@ func (s *sshServer) handleSession(ch gossh.Channel, reqs <-chan *gossh.Request) 
 	}
 }
 
-// ---------------------------------------------------------------------------
-// sshSession — controllable session handed to tests
-// ---------------------------------------------------------------------------
-
 // sshSession gives a test direct control over one established shell session.
 type sshSession struct {
 	send chan<- []byte // write here to push bytes to the client
@@ -149,9 +135,8 @@ type sshSession struct {
 	drop func()        // close the server-side channel immediately
 }
 
-// runSession is an onShell implementation for tests that need per-session
-// control. It pumps stdin/stdout and sends the session to out, then keeps the
-// channel alive until drop is called.
+// runSession gives tests control of session input, output, and disconnection. It keeps the channel
+// open until drop is called.
 func runSession(ch gossh.Channel, out chan<- *sshSession) {
 	sendCh := make(chan []byte, 16)
 	recvCh := make(chan []byte, 16)
@@ -166,7 +151,7 @@ func runSession(ch gossh.Channel, out chan<- *sshSession) {
 		}),
 	}
 
-	// stdin → recvCh
+	// Forward client input to recvCh.
 	go func() {
 		buf := make([]byte, 4096)
 		for {
@@ -186,7 +171,7 @@ func runSession(ch gossh.Channel, out chan<- *sshSession) {
 		}
 	}()
 
-	// sendCh → stdout
+	// Forward sendCh data to client output.
 	go func() {
 		for {
 			select {
@@ -207,11 +192,7 @@ func runSession(ch gossh.Channel, out chan<- *sshSession) {
 	<-dropped
 }
 
-// ---------------------------------------------------------------------------
-// Shared test helpers
-// ---------------------------------------------------------------------------
-
-// nodeAddr parses "host:port" and returns the components.
+// nodeAddr separates a network address into its host and port.
 func nodeAddr(t *testing.T, addr string) (host string, port int) {
 	t.Helper()
 	colon := strings.LastIndex(addr, ":")
@@ -224,8 +205,7 @@ func nodeAddr(t *testing.T, addr string) (host string, port int) {
 	return addr[:colon], port
 }
 
-// singleNode builds a one-node map and matching credentials map for tests
-// that only need a single SSH node.
+// singleNode builds matching inventory and credentials for one SSH node.
 func singleNode(t *testing.T, addr string) (id string, nodeMap map[string]*nodes.NodeConsoleInfo, passwords map[string]compcredentials.CompCredentials) {
 	t.Helper()
 	host, port := nodeAddr(t, addr)
@@ -244,7 +224,8 @@ func singleNode(t *testing.T, addr string) (id string, nodeMap map[string]*nodes
 	return
 }
 
-// startNodes follows service ordering by registering membership before delivering credentials.
+// startNodes follows service ordering by registering membership before credentials. The first
+// connection attempt therefore occurs after UpdateCredentials.
 func startNodes(
 	t *testing.T,
 	manager *ssh.SSHConsoleManager,
@@ -259,8 +240,7 @@ func startNodes(
 	manager.UpdateCredentials(passwords)
 }
 
-// makePasswordsWith builds a credential map assigning the same password to
-// every id.
+// makePasswordsWith assigns one password to every node.
 func makePasswordsWith(ids []string, password string) map[string]compcredentials.CompCredentials {
 	m := make(map[string]compcredentials.CompCredentials, len(ids))
 	for _, id := range ids {
@@ -269,12 +249,9 @@ func makePasswordsWith(ids []string, password string) map[string]compcredentials
 	return m
 }
 
-// newManager creates an SSHConsoleManager with fast reconnect intervals
-// suitable for tests.
-//
-// Pass logsDir as t.TempDir() at the call site — see waitOnCleanup for why the
-// order matters. Callers must cancel the context they hand to
-// UpdateNodes with defer, which runs before this cleanup.
+// newManager creates a manager with fast reconnect intervals. logsDir must come from t.TempDir
+// before this call so manager cleanup runs first. Callers must defer cancellation of the context
+// passed to UpdateNodes.
 func newManager(t *testing.T, logsDir string) *ssh.SSHConsoleManager {
 	t.Helper()
 	cfg := ssh.DefaultSSHConfig()
@@ -286,25 +263,16 @@ func newManager(t *testing.T, logsDir string) *ssh.SSHConsoleManager {
 	return manager
 }
 
-// waitOnCleanup makes a test wait for the manager's node goroutines before it
-// finishes.
-//
-// A node opens its log file as the first thing Run does, and the manager only
-// ever asks nodes to stop. A test that hands t.TempDir() to a manager and
-// returns without waiting races its own cleanup: RemoveAll empties the
-// directory, a node goroutine gets scheduled and recreates the log file, and
-// the final rmdir fails with "directory not empty".
-//
-// Cleanups run last-in-first-out, so as long as the caller obtained logsDir
-// from t.TempDir() before reaching here, the wait happens first and the
-// directory is empty when it is removed.
+// waitOnCleanup waits for node goroutines before temporary directory cleanup. Without it, Run can
+// recreate a log after directory removal begins and cause cleanup to fail. Calling t.TempDir
+// before registering this cleanup ensures the wait runs first.
 func waitOnCleanup(t *testing.T, manager *ssh.SSHConsoleManager) {
 	t.Helper()
 	t.Cleanup(manager.Wait)
 }
 
-// waitForMarker reads from ch until the accumulated output contains marker or
-// the timeout expires. Returns the full output seen.
+// waitForMarker reads until the accumulated output contains marker or the timeout expires. It
+// returns all output received.
 func waitForMarker(t *testing.T, ch <-chan []byte, marker string, timeout time.Duration) string {
 	t.Helper()
 	timer := time.NewTimer(timeout)


### PR DESCRIPTION
Keep SSH consoles idle until Vault provides their credentials instead of attempting invalid key authentication. Retry credential delivery independently of inventory changes so newly added nodes can start when their entries appear.