### PR TITLE
refactor(creds): maintain a complete credential snapshot

### DIFF
--- a/cmd/remote-console/service.go
+++ b/cmd/remote-console/service.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -37,9 +36,14 @@ type ConmanService interface {
 	SignalConmanHUP() error
 }
 
-// CredsService defines the interface for credentials service operations
+// CredsService defines the interface for credentials service operations.
+//
+// CheckForUpdates is what refreshes the service's view of the credential store;
+// GetPasswords serves that view without going near the store. Callers therefore
+// see credentials as of the last refresh, and only watchForCredUpdates calls
+// CheckForUpdates — see the note there for why that has to stay true.
 type CredsService interface {
-	GetPasswordsWithRetries(ctx context.Context, bmcXNames []string, maxTries, waitSecs int) (map[string]compcreds.CompCredentials, error)
+	GetPasswords(xnames []string) map[string]compcreds.CompCredentials
 	EnsureConsoleKeysPresent() (bool, error)
 	CheckForUpdates() (bool, error)
 }
@@ -95,7 +99,8 @@ func filterXNames(sshNodes map[string]*nodes.NodeConsoleInfo) []string {
 // Watch for node updates and signal conman and log rotation as needed.
 //
 // This loop decides membership only. Credentials belong to watchForCredUpdates,
-// which retries delivery for the current SSH nodes on every tick.
+// which pushes the credential snapshot at the SSH manager on every tick and so
+// picks up whatever this loop registered.
 func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpClient *http.Client,
 	conmanService ConmanService, logsService LogsService,
 	sshService SSHConsoleService) {
@@ -143,9 +148,14 @@ func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpC
 
 // Watch for credential updates and signal conman and SSH manager as needed.
 //
-// This loop is the sole owner of credential delivery to the SSH manager. It
-// fetches on every tick so a node added after startup receives its entry even
-// when nothing in Vault changed.
+// This loop is the only caller of CheckForUpdates, and that is a constraint
+// rather than a coincidence: CheckForUpdates reports what has changed since the
+// last call, so a second caller would consume changes this one needs to see and
+// conman would never be told to pick them up.
+//
+// It is also the sole owner of credential delivery to the SSH manager. Delivery
+// does not wait for a reported change — a node that registered after the last
+// tick needs its entry even though nothing in the store changed for it.
 func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig,
 	credsService CredsService, conmanService ConmanService, sshService SSHConsoleService) {
 	ticker := time.NewTicker(time.Duration(config.CredsMonitorInterval) * time.Second)
@@ -159,27 +169,12 @@ func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig,
 		case <-ticker.C:
 			changed, err := credsService.CheckForUpdates()
 			if err != nil {
+				// The refresh failed, so the previous snapshot still stands.
 				slog.Error("Failed to check for credential updates", "error", err)
 			}
 
-			// Only the SSH manager needs the passwords here. conman picks the
-			// new ones up when runConman rebuilds conman.conf after the SIGTERM
-			// below. A regular tick makes one attempt; a reported Vault change
-			// gets the existing retry budget.
-			sshNodes := filterSSHNodes(nodes.CurrentNodes())
-			if len(sshNodes) > 0 {
-				tries, wait := 1, 0
-				if changed {
-					tries, wait = 3, 5
-				}
-				passwords, err := credsService.GetPasswordsWithRetries(ctx, filterXNames(sshNodes), tries, wait)
-				if err != nil {
-					// Whatever came back is still worth applying. Absent node
-					// IDs are left alone, so a partial map only moves nodes
-					// forward onto credentials that arrived.
-					slog.Error("Failed to fetch updated credentials", "error", err)
-				}
-				sshService.UpdateCredentials(passwords)
+			if sshNodes := filterSSHNodes(nodes.CurrentNodes()); len(sshNodes) > 0 {
+				sshService.UpdateCredentials(credsService.GetPasswords(filterXNames(sshNodes)))
 			}
 
 			if changed {
@@ -265,15 +260,8 @@ func runConman(ctx context.Context, conmanService ConmanService, credService Cre
 		ipmiNodes := filterIPMINodes(currentNodes)
 
 		var passwords map[string]compcreds.CompCredentials
-		var err error
 		if len(ipmiNodes) > 0 {
-			passwords, err = credService.GetPasswordsWithRetries(ctx, filterXNames(ipmiNodes), 15, 10)
-			if err != nil {
-				slog.Warn("Credential retrieval ended early", "error", err)
-				if errors.Is(err, context.Canceled) {
-					return
-				}
-			}
+			passwords = credService.GetPasswords(filterXNames(ipmiNodes))
 		}
 
 		hasNodes, err := conmanService.ConfigureConman(ipmiNodes, passwords)

--- a/internal/creds/creds.go
+++ b/internal/creds/creds.go
@@ -9,20 +9,26 @@ package creds
 
 import (
 	"bytes"
-	"context"
 	"crypto/sha256"
 	"fmt"
 	"log/slog"
 	"os"
-	"time"
+	"sync"
 
 	compcreds "github.com/Cray-HPE/hms-compcredentials"
 	sstorage "github.com/Cray-HPE/hms-securestorage"
 )
 
 type CredsService struct {
-	config                 CredsConfig
-	previousPasswords      map[string]compcreds.CompCredentials
+	config CredsConfig
+
+	// passwordsMu guards passwords.
+	passwordsMu sync.RWMutex
+
+	// passwords is the credential snapshot from the last inventory refresh.
+	// checkIfPasswordsChanged is its only writer.
+	passwords map[string]compcreds.CompCredentials
+
 	previousPrivateKeyHash []byte
 	previousCertHash       []byte
 }
@@ -30,7 +36,7 @@ type CredsService struct {
 func NewCredsService(config CredsConfig) *CredsService {
 	return &CredsService{
 		config:                 config,
-		previousPasswords:      nil,
+		passwords:              nil,
 		previousPrivateKeyHash: nil,
 		previousCertHash:       nil,
 	}
@@ -96,52 +102,19 @@ func getPasswords(config CredsConfig, bmcXNames []string) (map[string]compcreds.
 	return ccreds, nil
 }
 
-// Look up the creds for the input endpoints with retries
-func (cs *CredsService) GetPasswordsWithRetries(ctx context.Context, bmcXNames []string, maxTries, waitSecs int) (map[string]compcreds.CompCredentials, error) {
-	var passwords map[string]compcreds.CompCredentials = nil
-	var err error = nil
-	for numTries := 0; numTries < maxTries; numTries++ {
-		select {
-		case <-ctx.Done():
-			slog.Info("Stopping credential retrieval due to context cancellation")
-			return passwords, ctx.Err()
-		default:
-		}
+// GetPasswords returns credentials from the last refresh for the given xnames.
+// Missing credentials are omitted. CheckForUpdates refreshes the snapshot.
+func (cs *CredsService) GetPasswords(xnames []string) map[string]compcreds.CompCredentials {
+	cs.passwordsMu.RLock()
+	defer cs.passwordsMu.RUnlock()
 
-		slog.Debug("Get passwords with retry", "attempt", numTries)
-		passwords, err = getPasswords(cs.config, bmcXNames)
-
-		slog.Debug("Passwords retrieved", "count", len(passwords))
-
-		if err != nil {
-			slog.Error("Error retrieving passwords", "error", err)
-		}
-
-		foundAll := true
-		for _, nn := range bmcXNames {
-			_, ok := passwords[nn]
-			if !ok {
-				slog.Warn("Missing credentials for", "xname", nn)
-				foundAll = false
-			}
-		}
-		if foundAll {
-			slog.Info("Retrieved all passwords")
-			break
-		}
-		slog.Warn("Only retrieved subset of creds from vault, waiting and trying again",
-			"attempt", numTries, "retrieved", len(passwords), "total", len(bmcXNames))
-
-		select {
-		case <-ctx.Done():
-			slog.Info("Stopping credential retrieval due to context cancellation")
-			return passwords, ctx.Err()
-		case <-time.After(time.Duration(waitSecs) * time.Second):
+	passwords := make(map[string]compcreds.CompCredentials, len(xnames))
+	for _, xname := range xnames {
+		if creds, ok := cs.passwords[xname]; ok {
+			passwords[xname] = creds
 		}
 	}
-	slog.Warn("Maximum password attempts reached, configuring conman with what we have")
-
-	return passwords, err
+	return passwords
 }
 
 func hashString(s string) ([]byte, error) {

--- a/internal/creds/monitor.go
+++ b/internal/creds/monitor.go
@@ -41,17 +41,27 @@ func (cs *CredsService) CheckForUpdates() (bool, error) {
 	return (len(ids) > 0 && passwordsChanged) || keysChanged, nil
 }
 
+// checkIfPasswordsChanged refreshes the credential snapshot and reports changes.
 func (cs *CredsService) checkIfPasswordsChanged(xnames []string) (bool, error) {
-	currentPasswords, err := getPasswords(cs.config, xnames)
+	if len(xnames) == 0 {
+		// Preserve the snapshot until inventory is available.
+		return false, nil
+	}
 
+	currentPasswords, err := getPasswords(cs.config, xnames)
 	if err != nil {
+		// A failed read does not invalidate the previous snapshot.
 		slog.Error("Error retrieving passwords while checking for credential changes", "error", err)
 		return false, err
 	}
 
-	if cs.previousPasswords == nil {
-		cs.previousPasswords = currentPasswords
-		return false, nil
+	cs.passwordsMu.Lock()
+	defer cs.passwordsMu.Unlock()
+
+	if cs.passwords == nil {
+		// Report a non-empty first read so ConMan receives initial credentials.
+		cs.passwords = currentPasswords
+		return len(currentPasswords) > 0, nil
 	}
 
 	changed := false
@@ -61,7 +71,13 @@ func (cs *CredsService) checkIfPasswordsChanged(xnames []string) (bool, error) {
 			slog.Warn("Missing credentials detected while checking for credential changes", "xname", xname)
 			continue
 		}
-		previousCreds := cs.previousPasswords[xname]
+
+		previousCreds, seen := cs.passwords[xname]
+		if !seen {
+			slog.Info("New credentials detected. Conman will be reconfigured.", "xname", xname)
+			changed = true
+			break
+		}
 
 		if (currentCreds.Username != previousCreds.Username) || (currentCreds.Password != previousCreds.Password) {
 			slog.Info("Change detected in the passwords. Conman will be reconfigured.")
@@ -70,9 +86,8 @@ func (cs *CredsService) checkIfPasswordsChanged(xnames []string) (bool, error) {
 		}
 	}
 
-	// Only the full inventory refresh owns this snapshot. Credential reads for
-	// a subset of nodes must not make every omitted node appear changed later.
-	cs.previousPasswords = currentPasswords
+	// Replace rather than merge, so entries for departed nodes fall away.
+	cs.passwords = currentPasswords
 
 	return changed, nil
 }

--- a/internal/creds/monitor_test.go
+++ b/internal/creds/monitor_test.go
@@ -5,7 +5,6 @@
 package creds
 
 import (
-	"context"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -15,31 +14,33 @@ import (
 	"github.com/Cray-HPE/hms-securestorage"
 )
 
-func TestCheckIfPasswordsChanged(t *testing.T) {
-	tempDir := t.TempDir()
+// storeCred writes a credential entry for one xname, as the credential store
+// would hold it.
+func storeCred(t *testing.T, ss securestorage.SecureStorage, xname, password string) {
+	t.Helper()
+	value := map[string]string{
+		"Username": "admin",
+		"Password": password,
+		"Xname":    xname,
+		"URL":      "https://" + xname + "/redfish/v1/Managers/BMC",
+	}
+	require.NoError(t, ss.Store(fmt.Sprintf("hms-creds/%s", xname), value))
+}
 
-	// Setup a local secure storage file
-	localStoreFilePath := filepath.Join(tempDir, "secure_store")
+// newTestCredsService returns a CredsService backed by a local secret store
+// holding one entry per xname in passwords, along with the store so the test can
+// change entries afterwards.
+func newTestCredsService(t *testing.T, passwords map[string]string) (*CredsService, securestorage.SecureStorage) {
+	t.Helper()
+
+	localStoreFilePath := filepath.Join(t.TempDir(), "secure_store")
 	localStoreKey, err := securestorage.GenerateMasterKey()
 	require.NoError(t, err)
 	ss, err := securestorage.NewLocalSecretStore(localStoreKey, localStoreFilePath, true)
 	require.NoError(t, err)
 
-	testPasswords := map[string]string{
-		"x0c0s1b0": "password1",
-		"x0c0s1b1": "password2",
-	}
-	nodes := []string{"x0c0s1b0", "x0c0s1b1"}
-
-	for node, password := range testPasswords {
-		value := map[string]string{
-			"Username": "admin",
-			"Password": password,
-			"Xname":    node,
-			"URL":      "https://" + node + "/redfish/v1/Managers/BMC",
-		}
-		err = ss.Store(fmt.Sprintf("hms-creds/%s", node), value)
-		require.NoError(t, err)
+	for xname, password := range passwords {
+		storeCred(t, ss, xname, password)
 	}
 
 	config := DefaultCredsConfig()
@@ -47,40 +48,147 @@ func TestCheckIfPasswordsChanged(t *testing.T) {
 	config.LocalStoreFilePath = localStoreFilePath
 	config.LocalStoreKey = localStoreKey
 
-	service := NewCredsService(config)
+	return NewCredsService(config), ss
+}
 
-	changed, err := service.checkIfPasswordsChanged(nodes)
-	if err != nil {
-		t.Fatalf("Error checking if passwords changed: %v", err)
-	}
+func TestCheckIfPasswordsChanged(t *testing.T) {
+	xnames := []string{"x0c0s1b0", "x0c0s1b1"}
+	service, ss := newTestCredsService(t, map[string]string{
+		"x0c0s1b0": "password1",
+		"x0c0s1b1": "password2",
+	})
 
-	require.False(t, changed, "Passwords should not have changed")
-
-	// Now change a password
-	value := map[string]string{
-		"Username": "admin",
-		"Password": "newpassword",
-		"Xname":    "x0c0s1b0",
-		"URL":      "https://x0c0s1b0/redfish/v1/Managers/BMC",
-	}
-	err = ss.Store("hms-creds/x0c0s1b0", value)
+	changed, err := service.checkIfPasswordsChanged(xnames)
 	require.NoError(t, err)
+	require.True(t, changed, "the first check learns every credential, so it reports a change")
 
-	changed, err = service.checkIfPasswordsChanged(nodes)
-	if err != nil {
-		t.Fatalf("Error checking if passwords changed: %v", err)
-	}
-
-	require.True(t, changed, "Passwords should have changed")
-
-	// Reading a subset for conman must not replace the complete comparison
-	// snapshot and make the omitted node look changed on every refresh.
-	_, err = service.GetPasswordsWithRetries(context.Background(), nodes[:1], 1, 0)
+	changed, err = service.checkIfPasswordsChanged(xnames)
 	require.NoError(t, err)
+	require.False(t, changed, "unchanged passwords should not report a change")
 
-	changed, err = service.checkIfPasswordsChanged(nodes)
+	storeCred(t, ss, "x0c0s1b0", "newpassword")
+
+	changed, err = service.checkIfPasswordsChanged(xnames)
 	require.NoError(t, err)
-	require.False(t, changed, "A subset read should not poison the credential snapshot")
+	require.True(t, changed, "a changed password should report a change")
+}
+
+// GetPasswords serves subsets without changing the stored snapshot.
+func TestGetPasswordsServesTheRecordedSnapshot(t *testing.T) {
+	ipmiNode, sshNode := "x0c0s1b0", "x0c0s2b0"
+	all := []string{ipmiNode, sshNode}
+
+	service, ss := newTestCredsService(t, map[string]string{
+		ipmiNode: "password1",
+		sshNode:  "password2",
+	})
+
+	require.Empty(t, service.GetPasswords(all), "nothing is known before the first check")
+
+	changed, err := service.checkIfPasswordsChanged(all)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	ipmiOnly := service.GetPasswords([]string{ipmiNode})
+	require.Len(t, ipmiOnly, 1)
+	require.Equal(t, "password1", ipmiOnly[ipmiNode].Password)
+	require.Empty(t, service.GetPasswords([]string{"x0c0s9b0"}), "an unknown node is absent, not empty")
+
+	changed, err = service.checkIfPasswordsChanged(all)
+	require.NoError(t, err)
+	require.False(t, changed, "reading one node's entry is not a change to another's")
+
+	storeCred(t, ss, sshNode, "newpassword")
+	require.Equal(t, "password2", service.GetPasswords(all)[sshNode].Password,
+		"the snapshot is what the last check read, not what the store holds now")
+
+	changed, err = service.checkIfPasswordsChanged(all)
+	require.NoError(t, err)
+	require.True(t, changed)
+	require.Equal(t, "newpassword", service.GetPasswords(all)[sshNode].Password,
+		"a check that reports a change should leave the new credentials behind")
+}
+
+// A first observation that found nothing is not news, and must not restart
+// conman for it. Recording the empty read is still right: the entry arriving
+// afterwards is what the change is.
+func TestFirstObservationWithNoEntriesIsNotAChange(t *testing.T) {
+	xnames := []string{"x0c0s1b0"}
+	// Another node's entry, so the store exists but holds nothing for xnames.
+	service, ss := newTestCredsService(t, map[string]string{"x0c0s9b0": "unrelated"})
+
+	changed, err := service.checkIfPasswordsChanged(xnames)
+	require.NoError(t, err)
+	require.False(t, changed, "a first read that found no entries is not a change")
+	require.NotNil(t, service.passwords, "the empty read should still be recorded")
+
+	storeCred(t, ss, "x0c0s1b0", "password1")
+
+	changed, err = service.checkIfPasswordsChanged(xnames)
+	require.NoError(t, err)
+	require.True(t, changed, "the entry arriving afterwards is the change")
+}
+
+// A failed fetch must leave the baseline alone. Recording its empty result would
+// switch detection off until some later fetch happened to succeed.
+func TestFailedCheckLeavesBaselineIntact(t *testing.T) {
+	xnames := []string{"x0c0s1b0"}
+	service, ss := newTestCredsService(t, map[string]string{"x0c0s1b0": "password1"})
+
+	changed, err := service.checkIfPasswordsChanged(xnames)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	workingAdapter := service.config.SecureStorageAdapter
+	service.config.SecureStorageAdapter = StorageAdapter("bogus")
+	changed, err = service.checkIfPasswordsChanged(xnames)
+	require.Error(t, err)
+	require.False(t, changed)
+	service.config.SecureStorageAdapter = workingAdapter
+
+	changed, err = service.checkIfPasswordsChanged(xnames)
+	require.NoError(t, err)
+	require.False(t, changed, "recovering from a failed fetch is not a credential change")
+
+	storeCred(t, ss, "x0c0s1b0", "newpassword")
+
+	changed, err = service.checkIfPasswordsChanged(xnames)
+	require.NoError(t, err)
+	require.True(t, changed, "detection should still work after a failed fetch")
+}
+
+// An entry appearing after the baseline was recorded is a real change: the node
+// was already in inventory but had no credentials yet.
+func TestNewlyProvisionedCredentialIsAChange(t *testing.T) {
+	existing, provisioned := "x0c0s1b0", "x0c0s1b1"
+	xnames := []string{existing, provisioned}
+
+	service, ss := newTestCredsService(t, map[string]string{existing: "password1"})
+
+	changed, err := service.checkIfPasswordsChanged(xnames)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	storeCred(t, ss, provisioned, "password2")
+
+	changed, err = service.checkIfPasswordsChanged(xnames)
+	require.NoError(t, err)
+	require.True(t, changed, "a newly provisioned entry should report a change")
+}
+
+// Before inventory arrives there is nothing worth recording. Seeding an empty
+// baseline would make every node read as newly provisioned on the next tick.
+func TestCheckWithNoNodesDoesNotRecordBaseline(t *testing.T) {
+	service, _ := newTestCredsService(t, map[string]string{"x0c0s1b0": "password1"})
+
+	changed, err := service.checkIfPasswordsChanged(nil)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Nil(t, service.passwords, "an empty check should not record a snapshot")
+
+	changed, err = service.checkIfPasswordsChanged([]string{"x0c0s1b0"})
+	require.NoError(t, err)
+	require.True(t, changed, "the empty check should not have counted as the first observation")
 }
 
 func TestCheckIfKeysChanged(t *testing.T) {

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -30,7 +30,7 @@ type SSHConsoleManager struct {
 	// consolesMu protects consoles.
 	consolesMu sync.RWMutex
 	consoles   map[string]*SSHConsole
-	cancels    map[string]context.CancelFunc
+	cancels map[string]context.CancelFunc
 
 	// running tracks Run goroutines through final cleanup.
 	running sync.WaitGroup
@@ -128,19 +128,10 @@ func (m *SSHConsoleManager) Wait() {
 	m.running.Wait()
 }
 
-// UpdateCredentials delivers Vault entries to managed nodes, reconnecting any
-// node whose entry differs from the one it is using. It is the only way
-// credentials enter the manager; UpdateNodes never touches them.
-//
-// Only node IDs present in passwords are considered. An absent node is left
-// alone rather than cleared: a credential that has not arrived is not evidence
-// that a node has none, and a fetch can come back short for reasons that have
-// nothing to do with the node. A caller may therefore pass whatever it managed
-// to fetch without first deciding whether the result is complete.
-//
-// Moving a node from password to key auth is done by clearing the password on
-// its Vault entry, not by deleting the entry — the username is still needed
-// either way. That arrives here as a changed entry and is applied normally.
+// UpdateCredentials reconnects managed nodes whose credentials changed. UpdateNodes handles
+// membership and never changes authentication. Missing entries leave existing credentials
+// unchanged because reads may be partial, and entries for unmanaged nodes are ignored. An empty
+// password selects key authentication.
 func (m *SSHConsoleManager) UpdateCredentials(passwords map[string]compcredentials.CompCredentials) {
 	m.consolesMu.RLock()
 	type pending struct {

--- a/internal/ssh/manager_test.go
+++ b/internal/ssh/manager_test.go
@@ -154,13 +154,8 @@ func TestUpdateNodesAddsAndRemovesNodes(t *testing.T) {
 	}
 }
 
-// TestUpdateCredentialsIgnoresAbsentNodes pins the property that lets callers
-// pass a credential map they cannot vouch for. GetPasswordsWithRetries returns
-// whatever it managed to fetch with a nil error once it exhausts its retries,
-// so an absent nodeID says nothing about the node — only that this fetch did
-// not bring it back. UpdateCredentials must therefore leave absent nodes alone:
-// treating absence as a change would tear down a working console every time the
-// credential store had a bad minute.
+// TestUpdateCredentialsIgnoresAbsentNodes verifies partial snapshots do not disrupt working
+// consoles. A missing entry is not evidence of deletion, so existing credentials remain active.
 func TestUpdateCredentialsIgnoresAbsentNodes(t *testing.T) {
 	sessionCh := make(chan *sshSession)
 	srv := newSSHServer(t, func(ch gossh.Channel) { runSession(ch, sessionCh) })
@@ -181,7 +176,7 @@ func TestUpdateCredentialsIgnoresAbsentNodes(t *testing.T) {
 	sess := <-sessionCh
 	waitForMarker(t, clientCh, "[Console "+id+" connected at", 15*time.Second)
 
-	// An empty map — every node absent. Nothing may happen to this connection.
+	// An empty update must leave the connection unchanged.
 	manager.UpdateCredentials(map[string]compcredentials.CompCredentials{})
 
 	select {


### PR DESCRIPTION
Let change detection own the store baseline and refresh one inventory-wide snapshot. Callers read subsets from that snapshot without narrowing or replacing the service view.