### PR TITLE
fix(service): preserve complete inventory and credential views

### DIFF
--- a/cmd/remote-console/service.go
+++ b/cmd/remote-console/service.go
@@ -60,20 +60,9 @@ type LogsService interface {
 // the concrete *ssh.SSHConsoleManager is passed to console.SetupRoutes, which
 // uses it directly.
 type SSHConsoleService interface {
-	UpdateNodes(ctx context.Context, sshNodes map[string]*nodes.NodeConsoleInfo) error
+	UpdateNodes(ctx context.Context, nodes map[string]*nodes.NodeConsoleInfo) error
 	UpdateCredentials(passwords map[string]compcreds.CompCredentials)
 	ReopenLogs()
-}
-
-// filterSSHNodes returns the subset of nodes with SSH connection type.
-func filterSSHNodes(allNodes map[string]*nodes.NodeConsoleInfo) map[string]*nodes.NodeConsoleInfo {
-	result := make(map[string]*nodes.NodeConsoleInfo)
-	for id, n := range allNodes {
-		if n.IsSSH() {
-			result[id] = n
-		}
-	}
-	return result
 }
 
 // filterIPMINodes returns the subset of nodes with IPMI connection type.
@@ -88,9 +77,9 @@ func filterIPMINodes(allNodes map[string]*nodes.NodeConsoleInfo) map[string]*nod
 }
 
 // filterXNames returns the xnames from a node map.
-func filterXNames(sshNodes map[string]*nodes.NodeConsoleInfo) []string {
-	xnames := make([]string, 0, len(sshNodes))
-	for id := range sshNodes {
+func filterXNames(nodes map[string]*nodes.NodeConsoleInfo) []string {
+	xnames := make([]string, 0, len(nodes))
+	for id := range nodes {
 		xnames = append(xnames, id)
 	}
 	return xnames
@@ -123,8 +112,7 @@ func watchForNodesUpdates(ctx context.Context, config remoteConsoleConfig, httpC
 
 				currentNodes := nodes.CurrentNodes()
 
-				sshNodes := filterSSHNodes(currentNodes)
-				if err := sshService.UpdateNodes(ctx, sshNodes); err != nil {
+				if err := sshService.UpdateNodes(ctx, currentNodes); err != nil {
 					slog.Error("Failed to update SSH console nodes", "error", err)
 				}
 
@@ -173,12 +161,11 @@ func watchForCredUpdates(ctx context.Context, config remoteConsoleConfig,
 				slog.Error("Failed to check for credential updates", "error", err)
 			}
 
-			if sshNodes := filterSSHNodes(nodes.CurrentNodes()); len(sshNodes) > 0 {
-				sshService.UpdateCredentials(credsService.GetPasswords(filterXNames(sshNodes)))
-			}
+			names := filterXNames(nodes.CurrentNodes())
+			sshService.UpdateCredentials(credsService.GetPasswords(names))
 
 			if changed {
-				slog.Info("Credential changes detected, restarting conman")
+				slog.Info("Credential changes detected, signaling conman to restart")
 				if err := conmanService.SignalConmanTERM(); err != nil {
 					slog.Error("Failed to signal conman with SIGTERM", "error", err)
 				}
@@ -398,6 +385,7 @@ func runService(config remoteConsoleConfig) error {
 			// This is a fatal error - don't start with unprotected endpoints
 			slog.Error("Failed to initialize JWT authentication after all retries - refusing to start with unprotected endpoints")
 			serviceStopCtx()
+			sshManager.Shutdown()
 			return fmt.Errorf("failed to fetch JWKS from %s: %w", config.JwksURL, lastErr)
 		}
 	} else {
@@ -431,11 +419,9 @@ func runService(config remoteConsoleConfig) error {
 		sig := <-sigs
 		slog.Info("Detected signal to close service", "signal", sig)
 
-		// Cancel service context to stop background goroutines
-		serviceStopCtx()
-
 		// Shutdown signal with grace period of 30 seconds
 		shutdownCtx, shutdownCtxCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer shutdownCtxCancel()
 
 		go func() {
 			<-shutdownCtx.Done()
@@ -445,6 +431,10 @@ func runService(config remoteConsoleConfig) error {
 				os.Exit(1)
 			}
 		}()
+
+		// Stop background goroutines and wait for SSH console cleanup
+		serviceStopCtx()
+		sshManager.Shutdown()
 
 		// Trigger graceful shutdown
 		err := server.Shutdown(shutdownCtx)

--- a/internal/creds/monitor.go
+++ b/internal/creds/monitor.go
@@ -10,6 +10,7 @@ package creds
 import (
 	"log/slog"
 
+	compcreds "github.com/Cray-HPE/hms-compcredentials"
 	"github.com/OpenCHAMI/remote-console/internal/nodes"
 )
 
@@ -58,10 +59,22 @@ func (cs *CredsService) checkIfPasswordsChanged(xnames []string) (bool, error) {
 	cs.passwordsMu.Lock()
 	defer cs.passwordsMu.Unlock()
 
+	// Retain previous credentials when a read omits an inventoried node.
+	refreshed := make(map[string]compcreds.CompCredentials, len(xnames))
+	for _, xname := range xnames {
+		if creds, ok := currentPasswords[xname]; ok {
+			refreshed[xname] = creds
+			continue
+		}
+		if previous, seen := cs.passwords[xname]; seen {
+			refreshed[xname] = previous
+		}
+	}
+
 	if cs.passwords == nil {
 		// Report a non-empty first read so ConMan receives initial credentials.
-		cs.passwords = currentPasswords
-		return len(currentPasswords) > 0, nil
+		cs.passwords = refreshed
+		return len(refreshed) > 0, nil
 	}
 
 	changed := false
@@ -86,8 +99,7 @@ func (cs *CredsService) checkIfPasswordsChanged(xnames []string) (bool, error) {
 		}
 	}
 
-	// Replace rather than merge, so entries for departed nodes fall away.
-	cs.passwords = currentPasswords
+	cs.passwords = refreshed
 
 	return changed, nil
 }

--- a/internal/creds/monitor_test.go
+++ b/internal/creds/monitor_test.go
@@ -176,6 +176,66 @@ func TestNewlyProvisionedCredentialIsAChange(t *testing.T) {
 	require.True(t, changed, "a newly provisioned entry should report a change")
 }
 
+// A short read is not evidence that an entry was deleted rather than merely
+// unavailable. Keep serving the last observation while the node remains in
+// inventory, but let inventory removal discard it.
+func TestMissingCredentialRetainsPreviousEntryUntilNodeLeavesInventory(t *testing.T) {
+	present, missing := "x0c0s1b0", "x0c0s1b1"
+	all := []string{present, missing}
+	service, ss := newTestCredsService(t, map[string]string{
+		present: "password1",
+		missing: "password2",
+	})
+
+	changed, err := service.checkIfPasswordsChanged(all)
+	require.NoError(t, err)
+	require.True(t, changed)
+
+	require.NoError(t, ss.Delete("hms-creds/"+missing))
+
+	changed, err = service.checkIfPasswordsChanged(all)
+	require.NoError(t, err)
+	require.False(t, changed, "an absent read is not a credential change")
+	require.Equal(t, "password2", service.GetPasswords(all)[missing].Password,
+		"the last-known credential should remain available")
+
+	changed, err = service.checkIfPasswordsChanged(all)
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.Contains(t, service.GetPasswords(all), missing,
+		"subsequent short reads should not poison the snapshot")
+
+	changed, err = service.checkIfPasswordsChanged([]string{present})
+	require.NoError(t, err)
+	require.False(t, changed)
+	require.NotContains(t, service.GetPasswords(all), missing,
+		"a credential should fall away when its node leaves inventory")
+}
+
+// GetCompCreds keys its result by the xname inside each returned value. Some
+// adapters return a zero value for a missing key, producing an entry under "".
+// Rebuilding from inventory must neither retain that artifact nor report it as
+// a first observation.
+func TestFirstObservationIgnoresCredentialOutsideInventory(t *testing.T) {
+	xname := "x0c0s1b0"
+	service, ss := newTestCredsService(t, map[string]string{"x0c0s9b0": "unrelated"})
+	require.NoError(t, ss.Store("hms-creds/"+xname, map[string]string{
+		"Username": "admin",
+		"Password": "password1",
+	}))
+
+	changed, err := service.checkIfPasswordsChanged([]string{xname})
+	require.NoError(t, err)
+	require.False(t, changed, "an entry not keyed by an inventory xname is not news")
+	require.NotNil(t, service.passwords)
+	require.Empty(t, service.passwords)
+
+	storeCred(t, ss, xname, "password1")
+	changed, err = service.checkIfPasswordsChanged([]string{xname})
+	require.NoError(t, err)
+	require.True(t, changed, "a correctly keyed entry arriving later is a change")
+}
+
 // Before inventory arrives there is nothing worth recording. Seeding an empty
 // baseline would make every node read as newly provisioned on the next tick.
 func TestCheckWithNoNodesDoesNotRecordBaseline(t *testing.T) {

--- a/internal/ssh/manager.go
+++ b/internal/ssh/manager.go
@@ -25,12 +25,12 @@ var ErrNotConnected = errors.New("ssh console node not connected")
 type SSHConsoleManager struct {
 	cfg      SSHConfig
 	keyPath  string
-	logsPath string // e.g. /var/log/conman/conman
+	logsPath string
 
 	// consolesMu protects consoles.
-	consolesMu sync.RWMutex
-	consoles   map[string]*SSHConsole
-	cancels map[string]context.CancelFunc
+	consolesMu   sync.RWMutex
+	consoles     map[string]*SSHConsole
+	shuttingDown bool
 
 	// running tracks Run goroutines through final cleanup.
 	running sync.WaitGroup
@@ -44,7 +44,6 @@ func NewSSHConsoleManager(cfg SSHConfig, keyPath, logsPath string) *SSHConsoleMa
 		keyPath:  keyPath,
 		logsPath: logsPath,
 		consoles: make(map[string]*SSHConsole),
-		cancels:  make(map[string]context.CancelFunc),
 	}
 }
 
@@ -65,41 +64,46 @@ func credsChanged(a, b compcredentials.CompCredentials) bool {
 	return a.Username != b.Username || a.Password != b.Password
 }
 
-// UpdateNodes syncs managed consoles with the provided SSH node set. It starts new SSH nodes and
-// stops removed nodes. Connection changes restart a console with its existing
+// UpdateNodes syncs managed consoles with the complete inventory. It starts new SSH nodes and
+// stops removed or retyped nodes. Connection changes restart a console with its existing
 // credentials, while new nodes wait for UpdateCredentials before connecting. ctx controls
 // console lifetime.
 func (m *SSHConsoleManager) UpdateNodes(
 	ctx context.Context,
-	sshNodes map[string]*nodes.NodeConsoleInfo,
+	nodes map[string]*nodes.NodeConsoleInfo,
 ) error {
 	m.consolesMu.Lock()
 	defer m.consolesMu.Unlock()
+	if m.shuttingDown {
+		return nil
+	}
 
-	// Stop the consoles of nodes that are no longer in the updated set.
-	for nodeID, cancel := range m.cancels {
-		if _, stillActive := sshNodes[nodeID]; !stillActive {
+	// Stop consoles for nodes that left inventory or are no longer SSH nodes.
+	for nodeID, console := range m.consoles {
+		info, present := nodes[nodeID]
+		if !present || info == nil || !info.IsSSH() {
 			slog.Info("Stopping SSH console", "nodeID", nodeID)
-			cancel()
+			console.cancel()
 			delete(m.consoles, nodeID)
-			delete(m.cancels, nodeID)
 		}
 	}
 
-	for nodeID, info := range sshNodes {
+	for nodeID, info := range nodes {
+		if info == nil || !info.IsSSH() {
+			continue
+		}
+
 		existing, exists := m.consoles[nodeID]
 		if !exists {
-			// nil credentials: the console parks until UpdateCredentials reaches it.
 			m.startConsole(ctx, nodeID, info, nil)
 			continue
 		}
 
 		if nodeChanged(existing.info, info) {
-			// Connection parameters changed — replace the console, carrying the
-			// credentials the old one was using.
+			// Preserve credentials when replacing the console.
 			slog.Info("SSH console node parameters changed, restarting", "nodeID", nodeID)
 			creds := existing.currentCreds()
-			m.cancels[nodeID]()
+			existing.cancel()
 			m.startConsole(ctx, nodeID, info, creds)
 		}
 	}
@@ -113,18 +117,31 @@ func (m *SSHConsoleManager) startConsole(ctx context.Context, nodeID string, inf
 	consoleCtx, consoleCancel := context.WithCancel(ctx)
 	console := newSSHConsole(nodeID, info, creds, m.keyPath, m.logPath(nodeID), m.cfg, consoleCancel)
 	m.consoles[nodeID] = console
-	m.cancels[nodeID] = consoleCancel
 	slog.Info("Starting SSH console", "nodeID", nodeID, "host", info.ConnectionHost)
-	m.running.Add(1)
-	go func() {
-		defer m.running.Done()
+	m.running.Go(func() {
 		console.Run(consoleCtx)
-	}()
+	})
 }
 
 // Wait blocks until all Run goroutines exit but does not stop them. Callers cancel their contexts
 // first and then wait for log cleanup.
 func (m *SSHConsoleManager) Wait() {
+	m.running.Wait()
+}
+
+// Shutdown stops all consoles and waits for their cleanup.
+func (m *SSHConsoleManager) Shutdown() {
+	m.consolesMu.Lock()
+	if !m.shuttingDown {
+		m.shuttingDown = true
+		for nodeID, console := range m.consoles {
+			slog.Info("Stopping SSH console", "nodeID", nodeID)
+			console.cancel()
+			delete(m.consoles, nodeID)
+		}
+	}
+	m.consolesMu.Unlock()
+
 	m.running.Wait()
 }
 
@@ -166,8 +183,8 @@ func (m *SSHConsoleManager) ReopenLogs() {
 // Attach connects a client and fails if the node is unmanaged.
 func (m *SSHConsoleManager) Attach(nodeID, clientID string) (chan []byte, error) {
 	m.consolesMu.RLock()
+	defer m.consolesMu.RUnlock()
 	console, ok := m.consoles[nodeID]
-	m.consolesMu.RUnlock()
 	if !ok {
 		return nil, fmt.Errorf("SSH console node %q not found", nodeID)
 	}

--- a/internal/ssh/manager_test.go
+++ b/internal/ssh/manager_test.go
@@ -154,6 +154,79 @@ func TestUpdateNodesAddsAndRemovesNodes(t *testing.T) {
 	}
 }
 
+// TestShutdownStopsConsoles verifies shutdown removes consoles and prevents later updates from
+// restarting them.
+func TestShutdownStopsConsoles(t *testing.T) {
+	id, nodeMap, _ := singleNode(t, deadAddr(t))
+	manager := ssh.NewSSHConsoleManager(ssh.DefaultSSHConfig(), "", t.TempDir())
+
+	if err := manager.UpdateNodes(context.Background(), nodeMap); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Attach(id, "before-shutdown"); err != nil {
+		t.Fatalf("node was not registered before shutdown: %v", err)
+	}
+	manager.Detach(id, "before-shutdown")
+
+	manager.Shutdown()
+
+	if _, err := manager.Attach(id, "after-shutdown"); err == nil {
+		t.Fatal("node remained registered after shutdown")
+	}
+	if err := manager.UpdateNodes(context.Background(), nodeMap); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Attach(id, "after-update"); err == nil {
+		t.Fatal("node restarted after shutdown")
+	}
+}
+
+// TestUpdateNodesSelectsSSHNodesFromCompleteInventory verifies only SSH nodes are registered.
+// Changing a node away from SSH removes its console.
+func TestUpdateNodesSelectsSSHNodesFromCompleteInventory(t *testing.T) {
+	sshID, ipmiID := "x0c0s1b0", "x0c0s2b0"
+	allNodes := map[string]*nodes.NodeConsoleInfo{
+		sshID: {
+			ID:             sshID,
+			ConnectionType: nodes.SSH,
+			ConnectionHost: "127.0.0.1",
+			ConnectionPort: 1,
+		},
+		ipmiID: {
+			ID:             ipmiID,
+			ConnectionType: nodes.IPMI,
+			ConnectionHost: "127.0.0.1",
+		},
+	}
+
+	manager := newManager(t, t.TempDir())
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := manager.UpdateNodes(ctx, allNodes); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Attach(sshID, "probe"); err != nil {
+		t.Fatalf("SSH node was not registered: %v", err)
+	}
+	manager.Detach(sshID, "probe")
+	if _, err := manager.Attach(ipmiID, "probe"); err == nil {
+		t.Fatal("IPMI node was registered by the SSH manager")
+	}
+
+	allNodes[sshID] = &nodes.NodeConsoleInfo{
+		ID:             sshID,
+		ConnectionType: nodes.IPMI,
+		ConnectionHost: "127.0.0.1",
+	}
+	if err := manager.UpdateNodes(ctx, allNodes); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := manager.Attach(sshID, "probe"); err == nil {
+		t.Fatal("node remained registered after changing from SSH to IPMI")
+	}
+}
+
 // TestUpdateCredentialsIgnoresAbsentNodes verifies partial snapshots do not disrupt working
 // consoles. A missing entry is not evidence of deletion, so existing credentials remain active.
 func TestUpdateCredentialsIgnoresAbsentNodes(t *testing.T) {


### PR DESCRIPTION
Retain last-known credentials when a store read is partial while dropping nodes that leave inventory. Pass complete views to the SSH manager and shut it down before the HTTP service exits.