### PR TITLE
feat(ssh): format console logs

### DIFF
--- a/internal/ssh/console.go
+++ b/internal/ssh/console.go
@@ -63,9 +63,10 @@ type SSHConsole struct {
 	stdinMu sync.Mutex
 
 	// logFile is opened at the start of Run and written only from the Run goroutine.
-	logFile     *os.File
-	logPath     string        // logsPath + "/console." + nodeID
-	reopenLogCh chan struct{} // buffered depth-1; signals broadcast to reopen after rotation
+	logFile      *os.File
+	logPath      string        // logsPath + "/console." + nodeID
+	reopenLogCh  chan struct{} // buffered depth-1; signals broadcast to reopen after rotation
+	logFormatter consoleLogFormatter
 
 	// cancel is called by the manager to stop the Run goroutine.
 	// ctx is NOT stored in the struct to avoid the go vet context-in-struct antipattern.
@@ -76,14 +77,15 @@ type SSHConsole struct {
 // node.cancel and call go node.Run(nodeCtx) after construction.
 func newSSHConsole(nodeID string, info *nodes.NodeConsoleInfo, creds compcredentials.CompCredentials, keyPath, logPath string, cfg SSHConfig) *SSHConsole {
 	return &SSHConsole{
-		nodeID:      nodeID,
-		info:        info,
-		keyPath:     keyPath,
-		cfg:         cfg,
-		creds:       creds,
-		clients:     make(map[string]*consoleClient),
-		logPath:     logPath,
-		reopenLogCh: make(chan struct{}, 1),
+		nodeID:       nodeID,
+		info:         info,
+		keyPath:      keyPath,
+		cfg:          cfg,
+		creds:        creds,
+		clients:      make(map[string]*consoleClient),
+		logPath:      logPath,
+		reopenLogCh:  make(chan struct{}, 1),
+		logFormatter: newConsoleLogFormatter(),
 	}
 }
 
@@ -460,6 +462,7 @@ func (c *SSHConsole) broadcast(data []byte) {
 		if c.logFile != nil {
 			_ = c.logFile.Close()
 		}
+		c.logFormatter.reset()
 		var err error
 		c.logFile, err = os.OpenFile(c.logPath, os.O_WRONLY|os.O_CREATE|os.O_APPEND, 0644)
 		if err != nil {
@@ -470,7 +473,8 @@ func (c *SSHConsole) broadcast(data []byte) {
 	}
 
 	if c.logFile != nil {
-		if _, err := c.logFile.Write(data); err != nil {
+		logData := c.logFormatter.format(data, time.Now())
+		if _, err := c.logFile.Write(logData); err != nil {
 			slog.Warn("Failed to write to SSH console log", "nodeID", c.nodeID, "error", err)
 		}
 	}

--- a/internal/ssh/log.go
+++ b/internal/ssh/log.go
@@ -1,0 +1,111 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package ssh
+
+import "time"
+
+const consoleLogTimestampFormat = "2006-01-02 15:04:05 "
+
+// consoleLogLineState tracks line boundaries that may span SSH reads.
+type consoleLogLineState uint8
+
+const (
+	consoleLogLineInit consoleLogLineState = iota // No line data has been written.
+	consoleLogLineData                            // The current line contains data.
+	consoleLogLineCR                              // A carriage return may be followed by a line feed.
+	consoleLogLineLF                              // The previous line ended.
+)
+
+// consoleLogFormatter matches ConMan line timestamps and sanitization.
+type consoleLogFormatter struct {
+	state consoleLogLineState
+}
+
+func newConsoleLogFormatter() consoleLogFormatter {
+	return consoleLogFormatter{}
+}
+
+func (f *consoleLogFormatter) reset() {
+	f.state = consoleLogLineInit
+}
+
+func (f *consoleLogFormatter) format(data []byte, now time.Time) []byte {
+	if len(data) == 0 {
+		return nil
+	}
+
+	timestamp := now.Format(consoleLogTimestampFormat)
+	formatted := make([]byte, 0, len(data)+len(timestamp))
+
+	// Preserve line state because SSH reads may split a line ending.
+	for _, b := range data {
+		switch b {
+		case '\r':
+			// Hold a carriage return until the next byte identifies the line ending.
+			switch f.state {
+			case consoleLogLineData:
+				f.state = consoleLogLineCR
+			case consoleLogLineInit:
+				formatted = append(formatted, timestamp...)
+				f.state = consoleLogLineCR
+			}
+
+		case '\n':
+			// Normalize line endings and mark the next byte as a new line.
+			if f.state == consoleLogLineInit || f.state == consoleLogLineLF {
+				formatted = append(formatted, timestamp...)
+			}
+			formatted = append(formatted, '\r', '\n')
+			f.state = consoleLogLineLF
+
+		case 0:
+			// ConMan ignores a NUL immediately after a line ending.
+			if f.state == consoleLogLineCR || f.state == consoleLogLineLF {
+				continue
+			}
+			formatted = f.appendByte(formatted, b, timestamp)
+
+		default:
+			formatted = f.appendByte(formatted, b, timestamp)
+		}
+	}
+
+	return formatted
+}
+
+func (f *consoleLogFormatter) appendByte(dst []byte, b byte, timestamp string) []byte {
+	// Complete a lone carriage return as a normalized line ending.
+	if f.state == consoleLogLineCR {
+		dst = append(dst, '\r', '\n')
+	}
+
+	// Timestamp only the first byte of each logical line.
+	if f.state != consoleLogLineData {
+		dst = append(dst, timestamp...)
+	}
+	f.state = consoleLogLineData
+
+	// Match ConMan caret and meta notation, which differs from strconv quoting.
+	c := b & 0x7f
+	switch {
+	case c < 0x20:
+		prefix := byte('^')
+		if b&0x80 != 0 {
+			prefix = '~'
+		}
+		return append(dst, prefix, c+'@')
+	case c == 0x7f:
+		prefix := byte('^')
+		if b&0x80 != 0 {
+			prefix = '~'
+		}
+		return append(dst, prefix, '?')
+	default:
+		if b&0x80 != 0 {
+			dst = append(dst, '`')
+		}
+		return append(dst, c)
+	}
+}

--- a/internal/ssh/log_test.go
+++ b/internal/ssh/log_test.go
@@ -1,0 +1,98 @@
+// Copyright © 2026 OpenCHAMI a Series of LF Projects, LLC
+//
+// SPDX-License-Identifier: MIT
+
+package ssh
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+)
+
+func TestConsoleLogFormatter(t *testing.T) {
+	now := time.Date(2026, time.July, 31, 12, 34, 56, 0, time.UTC)
+	timestamp := "2026-07-31 12:34:56 "
+
+	tests := []struct {
+		name  string
+		input []byte
+		want  []byte
+	}{
+		{
+			name:  "timestamps lines",
+			input: []byte("first\r\nsecond\n"),
+			want:  []byte(timestamp + "first\r\n" + timestamp + "second\r\n"),
+		},
+		{
+			name:  "sanitizes controls",
+			input: []byte{'a', '\t', 0x1b, 0x7f, 0x80, 0xff, '\n'},
+			want:  []byte(timestamp + "a^I^[^?~@~?\r\n"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			formatter := newConsoleLogFormatter()
+			if got := formatter.format(tt.input, now); !bytes.Equal(got, tt.want) {
+				t.Fatalf("format() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConsoleLogFormatterMaintainsLineState(t *testing.T) {
+	now := time.Date(2026, time.July, 31, 12, 34, 56, 0, time.UTC)
+	timestamp := "2026-07-31 12:34:56 "
+	formatter := newConsoleLogFormatter()
+
+	var got []byte
+	got = append(got, formatter.format([]byte("part"), now)...)
+	got = append(got, formatter.format([]byte("ial\r"), now)...)
+	got = append(got, formatter.format([]byte("\nnext\n"), now)...)
+
+	want := []byte(timestamp + "partial\r\n" + timestamp + "next\r\n")
+	if !bytes.Equal(got, want) {
+		t.Fatalf("split format() = %q, want %q", got, want)
+	}
+}
+
+func TestBroadcastFormatsOnlyLogOutput(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "console.node")
+	logFile, err := os.Create(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := logFile.Close(); err != nil {
+			t.Errorf("close log file: %v", err)
+		}
+	})
+
+	clientCh := make(chan []byte, 1)
+	console := &SSHConsole{
+		clients: map[string]*consoleClient{
+			"client": {ch: clientCh},
+		},
+		logFile:      logFile,
+		reopenLogCh:  make(chan struct{}, 1),
+		logFormatter: newConsoleLogFormatter(),
+	}
+	input := []byte("\x1b[31mred\r\n")
+	console.broadcast(input)
+
+	if got := <-clientCh; !bytes.Equal(got, input) {
+		t.Fatalf("client output = %q, want raw output %q", got, input)
+	}
+	logged, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := regexp.MustCompile(`^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} \^\[\[31mred\r\n$`)
+	if !want.Match(logged) {
+		t.Fatalf("log output = %q, want a timestamped and sanitized line", logged)
+	}
+}


### PR DESCRIPTION
Timestamp and sanitize SSH console log output while preserving raw data for attached clients. Maintain line state across reads and reset it after log rotation.